### PR TITLE
Added environmental variable hook for schema customisation 

### DIFF
--- a/followthemoney/__init__.py
+++ b/followthemoney/__init__.py
@@ -5,8 +5,11 @@ from followthemoney.util import set_model_locale
 
 __version__ = '1.3.15'
 
-model_path = os.path.dirname(__file__)
-model_path = os.path.join(model_path, 'schema')
+if os.environ.get('FTM_MODEL_PATH') is None:
+    model_path = os.path.dirname(__file__)
+    model_path = os.path.join(model_path, 'schema')
+else:
+    model_path = os.path.join(os.environ.get('FTM_MODEL_PATH'), 'schema')
 
 # Data model singleton
 model = Model(model_path)


### PR DESCRIPTION
Added environmental variable hook into __init__.py to allow customisation of the FTM repo without directly modifying the source.

Users can define the variable FTM_MODEL_PATH in their `aleph.env` file as their root directory. This directory must have a folder called "schema" inside.