### PR TITLE
Making error message on merge more informative

### DIFF
--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -254,7 +254,12 @@ class EntityProxy(object):
         model = self.schema.model
         other = self.from_dict(model, other)
         self.id = self.id or other.id
-        self.schema = model.common_schema(self.schema, other.schema)
+        try:
+            self.schema = model.common_schema(self.schema, other.schema)
+        except InvalidData as e:
+            msg = "Cannot merge entities with id %s: %s"
+            raise InvalidData(msg % (self.id, e))
+
         self.context.update(other.context)
         for prop, value in set(other.itervalues()):
             self.add(prop, value, cleaned=True, quiet=True)


### PR DESCRIPTION
It's unpleasant when merge fails like this:
```
followthemoney.exc.InvalidData: No common ancestor: <Schema('RingCompany')> and <Schema('UnknownLink')>

real	193m44.560s
user	140m55.059s
sys	41m27.904s
```
so I've made it fail like this:

```
followthemoney.exc.InvalidData: Cannot merge entities with id 91e4a8d4e517dce82ac58bedcbdec8dcf10f55b1: No common ancestor: <Schema('RingCompany')> and <Schema('UnknownLink')>

real	193m44.560s
user	140m55.059s
sys	41m27.904s
```