### PR TITLE
Added hasRange public variable to property

### DIFF
--- a/js/src/property.ts
+++ b/js/src/property.ts
@@ -31,6 +31,7 @@ export class Property {
   public readonly description: string | null
   public readonly stub: boolean
   public readonly hasReverse: boolean
+  public readonly hasRange: boolean
   private readonly range: string | null
   private readonly reverse: string | null
 
@@ -47,6 +48,7 @@ export class Property {
     this.range = property.range || null
     this.reverse = property.reverse || null
     this.type = schema.model.getType(property.type)
+    this.hasRange = this.range !== null
     this.hasReverse = this.range !== null && this.reverse !== null
   }
 

--- a/js/test/property.test.ts
+++ b/js/test/property.test.ts
@@ -5,7 +5,7 @@ describe('ftm/Property class', () => {
   const model = new Model(defaultModel)
   const schema = model.getSchema('Thing')
   let property: Property
-  beforeEach(() => {  
+  beforeEach(() => {
     property = new Property(schema, defaultModel.schemata.Thing.properties.address)
   })
   const requiredProperties = ['name', 'label', 'type']
@@ -21,6 +21,7 @@ describe('ftm/Property class', () => {
     const sameAs = schema.getProperty('sameAs');
     expect(sameAs).toBeInstanceOf(Property)
     expect(sameAs.hasReverse).toBeTruthy()
+    expect(sameAs.hasRange).toBeTruthy()
     expect(sameAs.getRange()).toBe(schema)
     expect(sameAs.getReverse()).toBe(sameAs)
   })
@@ -29,6 +30,7 @@ describe('ftm/Property class', () => {
     const nameProp = schema.getProperty('name');
     expect(nameProp).toBeInstanceOf(Property)
     expect(nameProp.hasReverse).toBeFalsy()
+    expect(nameProp.hasRange).toBeFalsy()
     expect(() => {
       nameProp.getRange()
     }).toThrow(Error)


### PR DESCRIPTION
Currently there is no way to check if a property has a range before calling the getRange() method, which throws an Invalid Schema error. 