### PR TITLE
Fix up value nodes in Neo4J export

### DIFF
--- a/followthemoney/export/graph.py
+++ b/followthemoney/export/graph.py
@@ -30,7 +30,9 @@ class GraphExporter(Exporter):
         return attributes
 
     def get_id(self, type_, value):
-        return str(type_.rdf(value))
+        if value is None:
+            return None
+        return type_.node_id(value)
 
     def write_edges(self, proxy):
         attributes = self.get_attributes(proxy)
@@ -90,7 +92,7 @@ class NXGraphExporter(GraphExporter):
         other_id = self.get_id(prop.type, value)
         if prop.type != registry.entity:
             self._make_node(node_id, {
-                'label': value,
+                'label': prop.type.caption(value),
                 'schema': prop.type.name
             })
         self.graph.add_edge(node_id, other_id,

--- a/followthemoney/types/address.py
+++ b/followthemoney/types/address.py
@@ -1,4 +1,5 @@
 import re
+from normality import slugify
 from normality.cleaning import collapse_spaces
 
 from followthemoney.types.common import PropertyType
@@ -32,3 +33,6 @@ class AddressType(PropertyType):
 
     def _specificity(self, value):
         return dampen(10, 60, value)
+
+    def node_id(self, value):
+        return 'addr:%s' % slugify(value)

--- a/followthemoney/types/common.py
+++ b/followthemoney/types/common.py
@@ -92,6 +92,12 @@ class PropertyType(object):
     def rdf(self, value):
         return Literal(value)
 
+    def node_id(self, value):
+        return str(self.rdf(value))
+
+    def caption(self, value):
+        return value
+
     def to_dict(self):
         data = {
             'label': gettext(self.label),

--- a/followthemoney/types/country.py
+++ b/followthemoney/types/country.py
@@ -69,6 +69,9 @@ class CountryType(PropertyType):
     def rdf(self, value):
         return URIRef('iso-3166-1:%s' % value)
 
+    def caption(self, value):
+        return self.names.get(value, value)
+
     def to_dict(self):
         data = super(CountryType, self).to_dict()
         data['values'] = self.names

--- a/followthemoney/types/date.py
+++ b/followthemoney/types/date.py
@@ -117,6 +117,9 @@ class DateType(PropertyType):
     def rdf(self, value):
         return Literal(value, datatype=XSD.dateTime)
 
+    def node_id(self, value):
+        return 'date:%s' % value
+
     def to_datetime(self, value):
         formats = self.DATE_PATTERNS_BY_LENGTH.get(len(value), [])
         for fmt in formats:

--- a/followthemoney/types/email.py
+++ b/followthemoney/types/email.py
@@ -52,4 +52,4 @@ class EmailType(PropertyType):
     # TODO: do we want to use TLDs as country evidence?
 
     def rdf(self, value):
-        return URIRef('mailto:%s' % value)
+        return URIRef('mailto:%s' % value.lower())

--- a/followthemoney/types/entity.py
+++ b/followthemoney/types/entity.py
@@ -27,3 +27,6 @@ class EntityType(PropertyType):
 
     def rdf(self, value):
         return URIRef('entity:%s' % value)
+
+    def caption(self, value):
+        return None

--- a/followthemoney/types/iban.py
+++ b/followthemoney/types/iban.py
@@ -30,3 +30,9 @@ class IbanType(PropertyType):
 
     def rdf(self, value):
         return URIRef('iban:%s' % value)
+
+    def node_id(self, value):
+        return str(self.rdf(value.upper()))
+
+    def caption(self, value):
+        return iban.format(value)

--- a/followthemoney/types/identifier.py
+++ b/followthemoney/types/identifier.py
@@ -37,3 +37,6 @@ class IdentifierType(PropertyType):
 
     def _specificity(self, value):
         return dampen(4, 10, value)
+
+    def node_id(self, value):
+        return 'id:%s' % value

--- a/followthemoney/types/json.py
+++ b/followthemoney/types/json.py
@@ -40,3 +40,6 @@ class JsonType(PropertyType):
         """Turn multiple values into a JSON array."""
         values = [self.unpack(v) for v in ensure_list(values)]
         return self.pack(values)
+
+    def node_id(self, value):
+        return None

--- a/followthemoney/types/language.py
+++ b/followthemoney/types/language.py
@@ -53,6 +53,9 @@ class LanguageType(PropertyType):
     def rdf(self, value):
         return URIRef('iso-639:%s' % value)
 
+    def caption(self, value):
+        return self.names.get(value, value)
+
     def to_dict(self):
         data = super(LanguageType, self).to_dict()
         data['values'] = self.names

--- a/followthemoney/types/mimetype.py
+++ b/followthemoney/types/mimetype.py
@@ -1,5 +1,5 @@
 from rdflib import URIRef
-from pantomime import normalize_mimetype, DEFAULT
+from pantomime import normalize_mimetype, parse_mimetype, DEFAULT
 
 from followthemoney.types.common import PropertyType
 from followthemoney.util import defer as _
@@ -19,3 +19,6 @@ class MimeType(PropertyType):
 
     def rdf(self, value):
         return URIRef('urn:mimetype:%s' % value)
+
+    def caption(self, value):
+        return parse_mimetype(value).label

--- a/followthemoney/types/name.py
+++ b/followthemoney/types/name.py
@@ -1,4 +1,5 @@
 from banal import ensure_list
+from normality import slugify
 from Levenshtein import jaro_winkler, setmedian
 from normality.cleaning import collapse_spaces, strip_quotes
 
@@ -35,3 +36,6 @@ class NameType(PropertyType):
 
     def compare(self, left, right):
         return jaro_winkler(left, right)
+
+    def node_id(self, value):
+        return 'name:%s' % slugify(value)

--- a/followthemoney/types/phone.py
+++ b/followthemoney/types/phone.py
@@ -59,3 +59,7 @@ class PhoneType(PropertyType):
 
     def rdf(self, value):
         return URIRef('tel:%s' % value)
+
+    def caption(self, value):
+        number = parse_number(value)
+        return format_number(number, PhoneNumberFormat.INTERNATIONAL)

--- a/followthemoney/types/string.py
+++ b/followthemoney/types/string.py
@@ -16,9 +16,15 @@ class TextType(PropertyType):
     matchable = False
     max_size = 30 * MEGABYTE
 
+    def node_id(self, value):
+        return None
+
 
 class HTMLType(PropertyType):
     name = 'html'
     label = _('HTML')
     matchable = False
     max_size = 30 * MEGABYTE
+
+    def node_id(self, value):
+        return None

--- a/followthemoney/types/url.py
+++ b/followthemoney/types/url.py
@@ -22,3 +22,6 @@ class UrlType(PropertyType):
 
     def rdf(self, value):
         return URIRef(value)
+
+    def node_id(self, value):
+        return 'url:%s' % value


### PR DESCRIPTION
This PR is an alternative implementation of #101. While reviewing that PR I noticed that it was actually a work-around to the fact that node IDs aren't always properly qualified. So I implemented a method for each data type to make a valid node ID. While at it, I decided to also make a second method that would return a nicely-formatted label for a node. This is cool for countries and similar, where we actually have proper labels as metadata.

I also changed the export form for nodes so that any node (no matter what type) will now have a `caption` field that can easily be used as a UI label.

/cc @dchaplinsky 