### PR TITLE
Maintain the order of property values

### DIFF
--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -5,6 +5,7 @@ from rdflib import Literal, URIRef
 from collections.abc import Hashable
 from rdflib.namespace import RDF, SKOS
 from banal import ensure_list, is_mapping, ensure_dict
+from ordered_set import OrderedSet
 
 from followthemoney.exc import InvalidData
 from followthemoney.types import registry
@@ -114,7 +115,7 @@ class EntityProxy(object):
             self._size += value_size
 
             if prop not in self._properties:
-                self._properties[prop] = set()
+                self._properties[prop] = OrderedSet()
             self._properties[prop].add(value)
 
     def set(self, prop, values, cleaned=False, quiet=False):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
         'pytz >= 2018.5',
         'rdflib >= 4.2.2',
         'networkx >= 2.4',
-        'openpyxl >= 3.0.1',
+        'openpyxl >= 3.0.3',
+        'ordered-set >= 3.1.1',
     ],
     extras_require={
         'dev': [

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -224,3 +224,9 @@ class ProxyTestCase(TestCase):
 
         proxy = model.make_entity('Person')
         assert 0 == len(list(proxy.triples()))
+
+    def test_properties_maintain_order(self):
+        proxy = EntityProxy.from_dict(model, ENTITY)
+        countries = ['gb', 'us', 'nl', 'in', 'jp', 'au', 'nz', 'sl']
+        proxy.set('country', countries)
+        assert proxy.get('country') == countries, proxy.get('country')


### PR DESCRIPTION
VIS captions are based on the first value from the list of values. Without some fixed order, caption will change randomly in the UI.

Alternatively, instead of insertion order, we can maintain an order based on insertion count?