### PR TITLE
Introduce Calls, Messages and UserAccounts

### DIFF
--- a/followthemoney/schema/Call.yaml
+++ b/followthemoney/schema/Call.yaml
@@ -1,0 +1,47 @@
+Call:
+  extends:
+  - Interval
+  label: "Call"
+  plural: "Calls"
+  matchable: false
+  generated: true
+  featured:
+  - callerNumber
+  - caller
+  - receiverNumber
+  - receiver
+  - date
+  caption:
+  - callerNumber
+  - receiverNumber
+  properties:
+    caller:
+      label: "Caller"
+      type: entity
+      range: LegalEntity
+      reverse:
+        name: callsMade
+        label: "Calls made"
+    callerNumber:
+      label: "Caller's Number"
+      type: phone
+    receiver:
+      label: "Receiver"
+      type: entity
+      range: LegalEntity
+      reverse:
+        name: callsReceived
+        label: "Calls received"
+    receiverNumber:
+      label: "Receiver's Number"
+      type: phone
+    duration:
+      label: "Call Duration in seconds"
+      type: number
+    recording:
+      label: "Recording of the call"
+      type: entity
+      range: Audio
+      reverse:
+        name: "recordedCall"
+        label: "Recording of"

--- a/followthemoney/schema/Call.yaml
+++ b/followthemoney/schema/Call.yaml
@@ -38,10 +38,10 @@ Call:
     duration:
       label: "Call Duration in seconds"
       type: number
-    recording:
-      label: "Recording of the call"
-      type: entity
-      range: Audio
-      reverse:
-        name: "recordedCall"
-        label: "Recording of"
+    # recording:
+    #   label: "Recording of the call"
+    #   type: entity
+    #   range: Audio
+    #   reverse:
+    #     name: "recordedCall"
+    #     label: "Recording of"

--- a/followthemoney/schema/Message.yaml
+++ b/followthemoney/schema/Message.yaml
@@ -1,0 +1,71 @@
+Message:
+  extends:
+    - Interval
+    - Folder
+    - PlainText
+    - HyperText
+  label: Message
+  plural: Messages
+  matchable: false
+  generated: true
+  featured:
+    - subject
+    - threadTopic
+    - date
+    - sender
+    - recipients
+  caption:
+    - subject
+    - threadTopic
+    - title
+    - fileName
+  properties:
+    subject:
+      label: Subject
+      type: string
+    threadTopic:
+      label: Thread topic
+      type: string
+    sender:
+      label: "Sender"
+      type: entity
+      range: LegalEntity
+      reverse:
+        name: messagesSent
+        label: "Messages sent"
+    senderAccount:
+      label: "Sender Account"
+      type: entity
+      range: UserAccount
+      reverse:
+        name: messagesSent
+        label: "Messages sent"
+    recipients:
+      label: "Recipients"
+      type: entity
+      range: LegalEntity
+      reverse:
+        name: messagesReceived
+        label: "messages received"
+    recipientAccount:
+      label: "Recipient Account"
+      type: entity
+      range: UserAccount
+      reverse:
+        name: messagesReceived
+        label: "Messages received"
+    inReplyTo:
+      label: "In Reply To"
+      description: "Message ID of the preceding message in the thread"
+      hidden: true
+    inReplyToMessage:
+      label: Responding to
+      type: entity
+      range: Message
+      reverse:
+        name: responses
+        label: "Responses"
+    metadata:
+      label: "Metadata"
+      hidden: true
+      type: json

--- a/followthemoney/schema/UserAccount.yaml
+++ b/followthemoney/schema/UserAccount.yaml
@@ -20,7 +20,7 @@ UserAccount:
       type: entity
       range: LegalEntity
       reverse:
-        name: useraccounts
+        name: userAccounts
         label: "User Accounts"
     service:
       label: "Service"

--- a/followthemoney/schema/UserAccount.yaml
+++ b/followthemoney/schema/UserAccount.yaml
@@ -1,0 +1,39 @@
+UserAccount:
+  extends:
+  - Thing
+  label: "UserAccount"
+  plural: "UserAccounts"
+  matchable: true
+  generated: true
+  featured:
+  - username
+  - service
+  - email
+  - owner
+  caption:
+  - username
+  - email
+  - service
+  properties:
+    owner:
+      label: "Owner"
+      type: entity
+      range: LegalEntity
+      reverse:
+        name: useraccounts
+        label: "User Accounts"
+    service:
+      label: "Service"
+      type: string
+    email:
+      label: "E-mail"
+      type: email
+    number:
+      label: "Phone Number"
+      type: phone
+    username:
+      label: "Username"
+      type: string
+    password:
+      label: "Password"
+      type: string


### PR DESCRIPTION
I decided not to add a `Communication` schema because the property names sort of vary among Call, Message and Email. For example, for calls we have `caller` as an `LegalEntity`, for Messages it's `sender`, but for emails `sender` is a string right now. And if we change that we have to reprocess a lot of data which I assume is not ideal? Should we make `Communication` just a symbolic class for now? (without any properties of its own)

refs #161 