### PR TITLE
Make property expansion optional when adding a node

### DIFF
--- a/followthemoney/graph.py
+++ b/followthemoney/graph.py
@@ -127,25 +127,26 @@ class Graph(object):
         if edge.weight > 0:
             self.edges[edge.id] = edge
 
-    def _add_node(self, proxy):
+    def _add_node(self, proxy, expand_properties=True):
         """Derive a node and its value edges from the given proxy."""
         entity = Node(registry.entity, proxy.id, proxy=proxy)
         self.nodes[entity.id] = entity
         for prop, value in proxy.itervalues():
             if prop.type.name not in self.edge_types:
                 continue
-            node = self._get_node_stub(value, prop)
-            edge = Edge(self, entity, node, prop=prop, value=value)
-            if edge.weight > 0:
-                self.edges[edge.id] = edge
+            if expand_properties:
+                node = self._get_node_stub(value, prop)
+                edge = Edge(self, entity, node, prop=prop, value=value)
+                if edge.weight > 0:
+                    self.edges[edge.id] = edge
 
-    def add(self, proxy):
+    def add(self, proxy, expand_properties=True):
         self.queue(proxy.id, proxy)
         if proxy.schema.edge:
             for (source, target) in proxy.edgepairs():
                 self._add_edge(proxy, source, target)
         else:
-            self._add_node(proxy)
+            self._add_node(proxy, expand_properties=expand_properties)
 
     def iternodes(self):
         return self.nodes.values()


### PR DESCRIPTION
<img width="632" alt="graph" src="https://user-images.githubusercontent.com/1142203/77058466-7d699280-69fb-11ea-9f10-23082e8e232a.png">

Suppose I have an expansion candidate like the graph in the image where `PersonA` and `PersonB` share a name and `PersonA` is director of `CompanyX` through `DirectorshipX`. And `PersonA` entity is the source of the expansion.

To construct the graph, we'll do:
```
graph.add(person_a)
graph.add(directorship_x)
graph.add(person_b)
```
Without any arguments graph doesn't know that we're interested in expanding property nodes of `PersonA` but not of `PersonB`. https://github.com/alephdata/followthemoney/blob/c9dc19150751f01d2cdddfc5f17273509a2d8dc6/followthemoney/graph.py#L137 will create nodes for the properties of `PersonB`. So we'll end up with extra layer of property expansion like in the image (the email node coming out of `PersonB` should not be created when expanding `PersonA`)