### PR TITLE
Remove bodyText from Message caption and featured properties

### DIFF
--- a/followthemoney/schema/Message.yaml
+++ b/followthemoney/schema/Message.yaml
@@ -10,7 +10,6 @@ Message:
   generated: true
   featured:
   - subject
-  - bodyText
   - date
   - sender
   - recipients
@@ -19,7 +18,6 @@ Message:
   - sender
   caption:
   - subject
-  - bodyText
   - title
   - threadTopic
   - fileName


### PR DESCRIPTION
We don't include `bodyText` in the entity result as it's excluded from ElasticSearch query result by default https://github.com/alephdata/aleph/blob/82fea8b1eba21462b74bdf4dd9eabe0574b234b9/aleph/index/entities.py#L20