### PR TITLE
Overwrite name for RealEstate and Vehicle

### DIFF
--- a/followthemoney/schema/RealEstate.yaml
+++ b/followthemoney/schema/RealEstate.yaml
@@ -15,6 +15,9 @@ RealEstate:
   - address
   - registrationNumber
   properties:
+    name:
+      label: "Real estate name"
+      type: string
     latitude:
       label: Latitude
       type: number

--- a/followthemoney/schema/Vehicle.yaml
+++ b/followthemoney/schema/Vehicle.yaml
@@ -13,6 +13,9 @@ Vehicle:
   - name
   - registrationNumber
   properties:
+    name:
+      label: "Vehicle name"
+      type: string
     registrationNumber:
       label: Registration Number
       type: identifier


### PR DESCRIPTION
Fixed the case when a mass of irrelevant titles for RealEstate and Vehicle become names.