### PR TITLE
Multi Part Proxy

### DIFF
--- a/followthemoney/multi_part_proxy.py
+++ b/followthemoney/multi_part_proxy.py
@@ -84,9 +84,13 @@ class MultiPartProxy(EntityProxy):
 
     def to_dict(self):
         return {
+            "id": self.id,
             "schema": self.schema.name,
             "parts": self.parts,
             "anti_parts": self.anti_parts,
             "proxies": self.proxies,
             "anti_proxies": self.anti_proxies,
         }
+
+    def __repr__(self):
+        return "<MPP(%r,%r)>" % (self.id, str(self))

--- a/followthemoney/multi_part_proxy.py
+++ b/followthemoney/multi_part_proxy.py
@@ -1,0 +1,92 @@
+from followthemoney.exc import InvalidData
+from followthemoney.proxy import EntityProxy
+
+
+class MultiPartProxy(EntityProxy):
+    def __init__(self, id=None, proxies=None, anti_proxies=None):
+        self.id = id
+        self.proxies = set(proxies or [])
+        self.anti_proxies = set(anti_proxies or [])
+        self._golden_proxy = None
+        self._build()
+
+    def _build(self):
+        if not self.proxies:
+            return
+        _golden_proxy = None
+        for proxy in self.proxies:
+            if _golden_proxy is None:
+                _golden_proxy = proxy.clone()
+            _golden_proxy.merge(proxy)
+        self._golden_proxy = _golden_proxy
+
+    def _merge_new_proxy(self, proxy):
+        if self._golden_proxy is None:
+            self._build()
+        self._golden_proxy.merge(proxy)
+
+    @property
+    def golden_proxy(self):
+        if self._golden_proxy is not None:
+            return self._golden_proxy.clone()
+        return None
+
+    @property
+    def schema(self):
+        return self._golden_proxy.schema
+
+    @property
+    def _properties(self):
+        return self._golden_proxy._properties
+
+    @property
+    def parts(self):
+        return [p.id for p in self.proxies]
+
+    @property
+    def anti_parts(self):
+        return [p.id for p in self.anti_proxies]
+
+    def add(self, prop, values):
+        raise NotImplementedError
+
+    def merge(self, other):
+        self.id = self.id or other.id
+        self.proxies.update(other.proxies - self.anti_proxies)
+        self.anti_proxies.update(other.anti_proxies - self.proxies)
+        self._build()
+        return self
+
+    def add_proxy(self, proxy):
+        if proxy not in self.proxies:
+            self.proxies.add(proxy)
+            try:
+                self._merge_new_proxy(proxy)
+            except InvalidData:
+                self.proxies.discard(proxy)
+                raise
+        self.anti_proxies.discard(proxy)
+
+    def add_anti_proxy(self, proxy):
+        self.anti_proxies.add(proxy)
+        if proxy in self.proxies:
+            self.proxies.discard(proxy)
+            self._build()
+
+    def discard(self, proxy):
+        self.anti_proxies.discard(proxy)
+        if proxy in self.proxies:
+            self.proxies.discard(proxy)
+            self._build()
+
+    def __contains__(self, proxy):
+        return proxy in self.proxies
+
+    def to_dict(self):
+        return {
+            "schema": self.schema.name,
+            "parts": self.parts,
+            "anti_parts": self.anti_parts,
+            "proxies": self.proxies,
+            "anti_proxies": self.anti_proxies,
+        }

--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -264,11 +264,11 @@ class EntityProxy(object):
         return self._size
 
     def __hash__(self):
-        return hash(self.id)
+        return hash(self.id or id(self))
 
     def __eq__(self, other):
         try:
-            return self.id == other.id
+            return self.id == other.id and not (self.id is None and other.id is None)
         except AttributeError:
             return False
 

--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from itertools import product
 from rdflib import Literal, URIRef  # type: ignore
 from rdflib.namespace import RDF, SKOS  # type: ignore
@@ -264,11 +265,21 @@ class EntityProxy(object):
         return self._size
 
     def __hash__(self):
-        return hash(self.id or id(self))
+        if not self.id:
+            warnings.warn(
+                "Taking the hash of an EntityProxy without an ID set results in undefined behaviour",
+                RuntimeWarning,
+            )
+        return hash(self.id)
 
     def __eq__(self, other):
         try:
-            return self.id == other.id and not (self.id is None and other.id is None)
+            if self.id is None or other.id is None:
+                warnings.warn(
+                    "Comparing EntityProxys without an ID set results in undefined behaviour",
+                    RuntimeWarning,
+                )
+            return self.id == other.id
         except AttributeError:
             return False
 

--- a/tests/test_multi_part_proxy.py
+++ b/tests/test_multi_part_proxy.py
@@ -1,0 +1,103 @@
+import random
+import string
+
+from unittest import TestCase
+
+from followthemoney import model
+from followthemoney.multi_part_proxy import MultiPartProxy
+
+
+ENTITY = {
+    "id": "test",
+    "schema": "Person",
+    "properties": {
+        "name": ["Ralph Tester"],
+        "birthDate": ["1972-05-01"],
+        "idNumber": ["9177171", "8e839023"],
+        "website": ["https://ralphtester.me"],
+        "phone": ["+12025557612"],
+        "email": ["info@ralphtester.me"],
+        "topics": ["role.spy"],
+    },
+}
+
+
+class MultiPartProxyTestCase(TestCase):
+    def test_base_functions(self):
+        a = model.get_proxy(ENTITY)
+        b = model.get_proxy(ENTITY)
+        mpp = MultiPartProxy(proxies=[a, b])
+        assert len(mpp.proxies) == 1
+        assert len(mpp.get("name")) == 1
+        assert mpp.get("name")[0] == "Ralph Tester"
+        mpp_keys = mpp.properties.keys()
+        assert set(a.properties.keys()) == mpp_keys
+        mpp_inv_keys = mpp.get_type_inverted().keys()
+        assert set(a.get_type_inverted().keys()) == mpp_inv_keys
+
+    def test_schema(self):
+        mpp = MultiPartProxy()
+        proxy = model.make_entity("Organization")
+        mpp.add_proxy(proxy)
+        assert mpp.schema.name == "Organization"
+
+        proxy = model.make_entity("PublicBody")
+        mpp.add_proxy(proxy)
+        assert mpp.schema.name == "PublicBody"
+
+        proxy = model.make_entity("Organization")
+        mpp.add_proxy(proxy)
+        assert mpp.schema.name == "PublicBody"
+
+    def test_get(self):
+        mpp = MultiPartProxy()
+        proxies = set()
+        for i in range(10):
+            name = "".join(random.sample(string.ascii_letters, 8))
+            proxy = model.make_entity("Person")
+            proxy.add("name", name)
+            mpp.add_proxy(proxy)
+            proxies.add(proxy)
+        assert len(mpp.proxies) == 10
+        assert len(mpp.get("name")) == 10
+        assert all(p in mpp for p in proxies)
+
+    def test_remove(self):
+        mpp = MultiPartProxy()
+        proxies = set()
+        for i in range(10):
+            name = "".join(random.sample(string.ascii_letters, 8))
+            proxy = model.make_entity("Person")
+            proxy.add("name", name)
+            mpp.add_proxy(proxy)
+            proxies.add(proxy)
+        remove = proxies.pop()
+        mpp.discard(remove)
+        assert len(mpp.proxies) == 9
+        assert len(mpp.get("name")) == 9
+        assert all(p in mpp for p in proxies)
+        assert remove not in mpp
+
+    def test_merge(self):
+        proxies = []
+        for i in range(3):
+            proxy = model.make_entity("Person")
+            proxies.append(proxy)
+        mpp1 = MultiPartProxy(proxies=[proxies[0]], anti_proxies=[proxies[1]])
+        mpp2 = MultiPartProxy(proxies=[proxies[2]], anti_proxies=[proxies[0]])
+        mpp1.merge(mpp2)
+
+        assert len(mpp1.proxies) == 2
+        assert len(mpp1.anti_proxies) == 1
+        assert proxies[0] in mpp1
+        assert proxies[1] in mpp1.anti_proxies
+        assert proxies[2] in mpp1
+
+        mpp1 = MultiPartProxy(proxies=[proxies[0]], anti_proxies=[proxies[1]])
+        mpp2 = MultiPartProxy(proxies=[proxies[1]], anti_proxies=[proxies[0]])
+        mpp1.merge(mpp2)
+
+        assert len(mpp1.proxies) == 1
+        assert len(mpp1.anti_proxies) == 1
+        assert proxies[0] in mpp1
+        assert proxies[1] in mpp1.anti_proxies

--- a/tests/test_multi_part_proxy.py
+++ b/tests/test_multi_part_proxy.py
@@ -22,6 +22,14 @@ ENTITY = {
 }
 
 
+def make_proxy(schema, **data):
+    proxy = model.make_entity(schema)
+    for k, v in data.items():
+        proxy.add(k, v)
+    proxy.make_id(*random.sample(string.ascii_letters, 24))
+    return proxy
+
+
 class MultiPartProxyTestCase(TestCase):
     def test_base_functions(self):
         a = model.get_proxy(ENTITY)
@@ -37,15 +45,15 @@ class MultiPartProxyTestCase(TestCase):
 
     def test_schema(self):
         mpp = MultiPartProxy()
-        proxy = model.make_entity("Organization")
+        proxy = make_proxy("Organization")
         mpp.add_proxy(proxy)
         assert mpp.schema.name == "Organization"
 
-        proxy = model.make_entity("PublicBody")
+        proxy = make_proxy("PublicBody")
         mpp.add_proxy(proxy)
         assert mpp.schema.name == "PublicBody"
 
-        proxy = model.make_entity("Organization")
+        proxy = make_proxy("Organization")
         mpp.add_proxy(proxy)
         assert mpp.schema.name == "PublicBody"
 
@@ -54,8 +62,7 @@ class MultiPartProxyTestCase(TestCase):
         proxies = set()
         for i in range(10):
             name = "".join(random.sample(string.ascii_letters, 8))
-            proxy = model.make_entity("Person")
-            proxy.add("name", name)
+            proxy = make_proxy("Person", name=name)
             mpp.add_proxy(proxy)
             proxies.add(proxy)
         assert len(mpp.proxies) == 10
@@ -67,8 +74,7 @@ class MultiPartProxyTestCase(TestCase):
         proxies = set()
         for i in range(10):
             name = "".join(random.sample(string.ascii_letters, 8))
-            proxy = model.make_entity("Person")
-            proxy.add("name", name)
+            proxy = make_proxy("Person", name=name)
             mpp.add_proxy(proxy)
             proxies.add(proxy)
         remove = proxies.pop()
@@ -81,7 +87,7 @@ class MultiPartProxyTestCase(TestCase):
     def test_merge(self):
         proxies = []
         for i in range(3):
-            proxy = model.make_entity("Person")
+            proxy = make_proxy("Person")
             proxies.append(proxy)
         mpp1 = MultiPartProxy(proxies=[proxies[0]], anti_proxies=[proxies[1]])
         mpp2 = MultiPartProxy(proxies=[proxies[2]], anti_proxies=[proxies[0]])


### PR DESCRIPTION
This creates a new EntityProxy subtype that transparently represents multiple underlying proxies. It works by containing a list of constituent proxies, in addition to a list of proxies that definitely don't belong to it. This will serve as a representation for profiles in aleph.