### PR TITLE
Cryptocurrency wallets

### DIFF
--- a/followthemoney/schema/BankAccount.yaml
+++ b/followthemoney/schema/BankAccount.yaml
@@ -1,6 +1,6 @@
 BankAccount:
-  label: Bank Account
-  plural: Bank Accounts
+  label: Bank account
+  plural: Bank accounts
   extends: Asset
   description: >
     An account held at a bank and controlled by an owner. This may also be used 
@@ -17,9 +17,9 @@ BankAccount:
     - accountNumber
   properties:
     bankName:
-      label: Bank Name
+      label: Bank name
     accountNumber:
-      label: Account Number
+      label: Account number
       type: identifier
     iban:
       label: IBAN

--- a/followthemoney/schema/CryptoWallet.yaml
+++ b/followthemoney/schema/CryptoWallet.yaml
@@ -26,7 +26,9 @@ CryptoWallet:
       label: Creation date
       type: date
     currencySymbol:
-      label: Short code for the currency
+      label: Currency short code
+    mangingExchange:
+      label: Managing exchange
     holder:
       label: Wallet holder
       type: entity

--- a/followthemoney/schema/CryptoWallet.yaml
+++ b/followthemoney/schema/CryptoWallet.yaml
@@ -1,0 +1,42 @@
+CryptoWallet:
+  label: Cryptocurrency wallet
+  plural: Cryptocurrency wallets
+  extends:
+    - Thing
+    - Value
+  description: >
+    A cryptocurrency wallet is a view on the transactions conducted by one participant
+    on a blockchain / distributed ledger system.
+  matchable: false
+  featured:
+    - currency
+    - publicKey
+  caption:
+    - publicKey
+    - name
+    - summary
+  properties:
+    publicKey:
+      label: Address
+      description: Public key used to identify the wallet
+      type: identifier
+    privateKey:
+      label: Private key
+    creationDate:
+      label: Creation date
+      type: date
+    currencySymbol:
+      label: Short code for the currency
+    holder:
+      label: Wallet holder
+      type: entity
+      range: LegalEntity
+      reverse:
+        name: cryptoWallets
+        label: "Cryptocurrency wallets"
+    balance:
+      label: Balance
+      type: number
+    balanceDate:
+      label: Balance date
+      type: date


### PR DESCRIPTION
This fixes #360 by adding support for blockchain wallets. The best alternative would have been to make a crypto wallet into a `BankAccount`, but they do seem to have separate properties. In particular, the `CryptoWallet` is implemented as based on `Value` and `Thing`, but not `Asset` because `CryptoWallets` are much less formally held through relations of ownership. Instead, a `CryptoWallet` has a `holder` of range `LegalEntity`.
