### PR TITLE
Adopt prefixdate library for parsing dates

### DIFF
--- a/followthemoney/types/date.py
+++ b/followthemoney/types/date.py
@@ -1,14 +1,12 @@
-import re
 import os
-import pytz
 import logging
+from prefixdate import parse, parse_format, Precision
 from rdflib import Literal  # type: ignore
 from rdflib.namespace import XSD  # type: ignore
-from datetime import datetime, date
 
 from followthemoney.types.common import PropertyType
 from followthemoney.util import defer as _
-from followthemoney.util import dampen, sanitize_text
+from followthemoney.util import dampen
 
 log = logging.getLogger(__name__)
 
@@ -22,35 +20,6 @@ class DateType(PropertyType):
     The timezone is always expected to be UTC and cannot be specified otherwise. There is
     no support for calendar weeks (``2021-W7``) and date ranges (``2021-2024``)."""
 
-    # JS: '^([12]\\d{3}(-[01]?[1-9](-[0123]?[1-9])?)?)?$'
-    REGEX_RAW = (
-        DATE
-    ) = r"^([12]\d{3}(-[01]?[0-9](-[0123]?[0-9]([T ]([012]?\d(:\d{1,2}(:\d{1,2}(\.\d{6})?(Z|[-+]\d{2}(:?\d{2})?)?)?)?)?)?)?)?)?$"
-    REGEX = re.compile(REGEX_RAW)
-    DATE_FULL = re.compile(r"\d{4}-\d{2}-\d{2}.*")
-    CUT_ZEROES = re.compile(r"((\-00.*)|(.00:00:00))$")
-    MONTH_FORMATS = re.compile(r"(%b|%B|%m|%c|%x)")
-    DAY_FORMATS = re.compile(r"(%d|%w|%c|%x)")
-    MAX_LENGTH = 19
-    DATE_PATTERNS_BY_LENGTH = {
-        19: ("%Y-%m-%dT%H:%M:%S",),
-        18: ("%Y-%m-%dT%H:%M:%S",),
-        17: ("%Y-%m-%dT%H:%M:%S",),
-        16: ("%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"),
-        15: ("%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"),
-        14: ("%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"),
-        13: ("%Y-%m-%dT%H", "%Y-%m-%dT%H:%M"),
-        12: ("%Y-%m-%dT%H", "%Y-%m-%dT%H:%M"),
-        11: ("%Y-%m-%dT%H",),
-        10: ("%Y-%m-%d", "%Y-%m-%dT%H"),
-        9: ("%Y-%m-%d",),
-        8: ("%Y-%m-%d",),
-        7: ("%Y-%m",),
-        6: ("%Y-%m",),
-        5: (),
-        4: ("%Y",),
-    }
-
     name = "date"
     group = "dates"
     label = _("Date")
@@ -59,64 +28,14 @@ class DateType(PropertyType):
 
     def validate(self, obj, **kwargs):
         """Check if a thing is a valid date."""
-        obj = sanitize_text(obj)
-        if obj is None:
-            return False
-        return self.REGEX.match(obj) is not None
-
-    def _clean_datetime(self, obj):
-        """Python objects want to be text."""
-        if isinstance(obj, datetime):
-            # if it's not naive, put it on zulu time first:
-            if obj.tzinfo is not None:
-                obj = obj.astimezone(pytz.utc)
-            return obj.isoformat()[: self.MAX_LENGTH]
-        if isinstance(obj, date):
-            return obj.isoformat()
-
-    def _clean_text(self, text):
-        # limit to the date part of a presumed date string
-        # FIXME: this may get us rid of TZ info?
-        text = text[: self.MAX_LENGTH]
-        if not self.validate(text):
-            return None
-        text = text.replace(" ", "T")
-        # fix up dates like 2017-1-5 into 2017-01-05
-        if not self.DATE_FULL.match(text):
-            parts = text.split("T", 1)
-            date = [p.zfill(2) for p in parts[0].split("-")]
-            parts[0] = "-".join(date)
-            text = "T".join(parts)
-            text = text[: self.MAX_LENGTH]
-        # strip -00-00 from dates because it makes ES barf.
-        text = self.CUT_ZEROES.sub("", text)
-        return text
+        prefix = parse(obj)
+        return prefix.precision != Precision.EMPTY
 
     def clean(self, text, format=None, **kwargs):
         """The classic: date parsing, every which way."""
-        # handle date/datetime before converting to text.
-        date = self._clean_datetime(text)
-        if date is not None:
-            return date
-
-        text = sanitize_text(text)
-        if text is None:
-            return
-
         if format is not None:
-            # parse with a specified format
-            try:
-                obj = datetime.strptime(text, format)
-                text = obj.date().isoformat()
-                if self.MONTH_FORMATS.search(format) is None:
-                    text = text[:4]
-                elif self.DAY_FORMATS.search(format) is None:
-                    text = text[:7]
-                return text
-            except Exception:
-                return None
-
-        return self._clean_text(text)
+            return parse_format(text, format).text
+        return parse(text).text
 
     def _specificity(self, value):
         return dampen(5, 13, value)
@@ -132,17 +51,7 @@ class DateType(PropertyType):
         return "date:%s" % value
 
     def to_datetime(self, value):
-        if value is None:
-            return
-        value = value[: self.MAX_LENGTH]
-        formats = self.DATE_PATTERNS_BY_LENGTH.get(len(value), ())
-        for fmt in formats:
-            try:
-                dt = datetime.strptime(value, fmt)
-                return dt.replace(tzinfo=pytz.UTC)
-            except Exception:
-                continue
-        log.debug("Date cannot be parsed %r: %s", formats, value)
+        return parse(value).dt
 
     def to_number(self, value):
         date = self.to_datetime(value)

--- a/followthemoney/types/date.py
+++ b/followthemoney/types/date.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from datetime import timezone
 from prefixdate import parse, parse_format, Precision
 from rdflib import Literal  # type: ignore
 from rdflib.namespace import XSD  # type: ignore
@@ -56,4 +57,7 @@ class DateType(PropertyType):
     def to_number(self, value):
         date = self.to_datetime(value)
         if date is not None:
+            # We make a best effort all over the app to ensure all times are in UTC.
+            if date.tzinfo is None:
+                date = date.replace(tzinfo=timezone.utc)
             return date.timestamp()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "sqlalchemy >= 1.2.0, < 2.0.0",
         "countrynames >= 1.9.1, < 2.0.0",
         "languagecodes >= 1.0.9, < 2.0.0",
-        "prefixdate >= 0.3.0, < 1.0.0",
+        "prefixdate >= 0.4.0, < 1.0.0",
         "fingerprints >= 1.0.1, < 2.0.0",
         "phonenumbers >= 8.12.22, < 9.0.0",
         "python-stdnum >= 1.16, < 2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "sqlalchemy >= 1.2.0, < 2.0.0",
         "countrynames >= 1.9.1, < 2.0.0",
         "languagecodes >= 1.0.9, < 2.0.0",
+        "prefixdate >= 0.3.0, < 1.0.0",
         "fingerprints >= 1.0.1, < 2.0.0",
         "phonenumbers >= 8.12.22, < 9.0.0",
         "python-stdnum >= 1.16, < 2.0.0",

--- a/tests/types/test_dates.py
+++ b/tests/types/test_dates.py
@@ -36,14 +36,14 @@ class DatesTest(unittest.TestCase):
         self.assertEqual(dates.clean("2017-00-00"), "2017")
         self.assertEqual(dates.clean("2017-00-00T00:00:00"), "2017")
         self.assertEqual(dates.clean("2017-00-00T12:03:49"), "2017")
-        self.assertEqual(dates.clean("2017-01-01T00:00:00"), "2017-01-01")
+        self.assertEqual(dates.clean("2017-01-01T00:00:00"), "2017-01-01T00:00:00")
 
     def test_patch_dates(self):
         self.assertEqual(dates.clean("2017-1-3"), "2017-01-03")
         self.assertEqual(dates.clean("2017-3"), "2017-03")
         self.assertEqual(dates.clean("2017-0"), "2017")
-        self.assertEqual(dates.clean("2017-5-2T00:00:00"), "2017-05-02")
-        self.assertEqual(dates.clean("2017-5-2T10:00:00"), "2017-05-02T10")
+        self.assertEqual(dates.clean("2017-5-2T00:00:00"), "2017-05-02T00:00:00")
+        self.assertEqual(dates.clean("2017-5-2T10:00:00"), "2017-05-02T10:00:00")
 
     def test_convert_datetime(self):
         dt = datetime.utcnow()

--- a/tests/types/test_dates.py
+++ b/tests/types/test_dates.py
@@ -43,9 +43,7 @@ class DatesTest(unittest.TestCase):
         self.assertEqual(dates.clean("2017-3"), "2017-03")
         self.assertEqual(dates.clean("2017-0"), "2017")
         self.assertEqual(dates.clean("2017-5-2T00:00:00"), "2017-05-02")
-        self.assertEqual(
-            dates.clean("2017-5-2T10:00:00"), "2017-05-02T10:00:00"
-        )  # noqa
+        self.assertEqual(dates.clean("2017-5-2T10:00:00"), "2017-05-02T10")
 
     def test_convert_datetime(self):
         dt = datetime.utcnow()
@@ -76,10 +74,10 @@ class DatesTest(unittest.TestCase):
         self.assertGreater(dates.compare("2011-01-01", "2011-01-01"), 0.9)
 
     def test_cast_num(self):
-        self.assertEqual(dates.to_number("2017-04-04T10:30:29"), 1491301829.0)
-        self.assertEqual(dates.to_number("2017-04-04T10:30"), 1491301800.0)
-        self.assertEqual(dates.to_number("2017-04-04T10"), 1491300000.0)
-        self.assertEqual(dates.to_number("2017-04-04"), 1491264000.0)
-        self.assertEqual(dates.to_number("2017-4-4"), 1491264000.0)
-        self.assertEqual(dates.to_number("2017-4"), 1491004800.0)
-        self.assertEqual(dates.to_number("2017"), 1483228800.0)
+        self.assertEqual(dates.to_number("2017-04-04T10:30:29"), 1491294629.0)
+        self.assertEqual(dates.to_number("2017-04-04T10:30"), 1491294600.0)
+        self.assertEqual(dates.to_number("2017-04-04T10"), 1491292800.0)
+        self.assertEqual(dates.to_number("2017-04-04"), 1491256800.0)
+        self.assertEqual(dates.to_number("2017-4-4"), 1491256800.0)
+        self.assertEqual(dates.to_number("2017-4"), 1490997600.0)
+        self.assertEqual(dates.to_number("2017"), 1483225200.0)

--- a/tests/types/test_dates.py
+++ b/tests/types/test_dates.py
@@ -74,10 +74,10 @@ class DatesTest(unittest.TestCase):
         self.assertGreater(dates.compare("2011-01-01", "2011-01-01"), 0.9)
 
     def test_cast_num(self):
-        self.assertEqual(dates.to_number("2017-04-04T10:30:29"), 1491294629.0)
-        self.assertEqual(dates.to_number("2017-04-04T10:30"), 1491294600.0)
-        self.assertEqual(dates.to_number("2017-04-04T10"), 1491292800.0)
-        self.assertEqual(dates.to_number("2017-04-04"), 1491256800.0)
-        self.assertEqual(dates.to_number("2017-4-4"), 1491256800.0)
-        self.assertEqual(dates.to_number("2017-4"), 1490997600.0)
-        self.assertEqual(dates.to_number("2017"), 1483225200.0)
+        self.assertEqual(dates.to_number("2017-04-04T10:30:29"), 1491301829.0)
+        self.assertEqual(dates.to_number("2017-04-04T10:30"), 1491301800.0)
+        self.assertEqual(dates.to_number("2017-04-04T10"), 1491300000.0)
+        self.assertEqual(dates.to_number("2017-04-04"), 1491264000.0)
+        self.assertEqual(dates.to_number("2017-4-4"), 1491264000.0)
+        self.assertEqual(dates.to_number("2017-4"), 1491004800.0)
+        self.assertEqual(dates.to_number("2017"), 1483228800.0)


### PR DESCRIPTION
This would adopt the `prefixdate` library, which makes some of the logic of the existing date parsing more explicit. When applied, this should:

a) Speed up date processing, both for format-string based parsing and for normal validation. 
b) Truncate prefixes for minutes and seconds from times when they are `00`. 
c) Fix an apparent issue with time zone conversion in `to_datetime`. 