### PR TITLE
Add a few fields to the sanctions model

### DIFF
--- a/followthemoney/schema/Sanction.yaml
+++ b/followthemoney/schema/Sanction.yaml
@@ -24,8 +24,16 @@ Sanction:
       range: Thing
     authority:
       label: "Authority"
+    authorityId:
+      label: "Authority-issued identifier"
+      type: identifier
+    unscId:
+      label: "UN SC identifier"
+      type: identifier
     program:
       label: "Program"
+    provisions:
+      label: "Scope of sanctions"
     status:
       label: "Status"
     duration:


### PR DESCRIPTION
This is to be able to more explicitly preserve UN security council IDs, and make a distinction between the sanctions programme and consequences that a target is facing. 