### PR TITLE
Add createdAt prop to all Things

### DIFF
--- a/followthemoney/schema/Thing.yaml
+++ b/followthemoney/schema/Thing.yaml
@@ -91,9 +91,14 @@ Thing:
       label: Index text
       hidden: true
       type: text
+    createdAt:
+      label: "Created at"
+      type: date
+      matchable: false
     modifiedAt:
       label: "Modified on"
       type: date
+      matchable: false
     retrievedAt:
       label: "Retrieved on"
       type: date


### PR DESCRIPTION
This could possibly replace the `Document.authoredAt` property at some point, if we wanted it to. I'm not sure why that prop name on `Document` was made so overly specific. 