### PR TITLE
Make Address matchable

### DIFF
--- a/followthemoney/property.py
+++ b/followthemoney/property.py
@@ -97,7 +97,11 @@ class Property:
         self.type = registry[type_]
 
         #: Whether this property should be used for matching and cross-referencing.
-        self.matchable = as_bool(data.get("matchable", self.type.matchable))
+        _matchable = data.get("matchable")
+        if _matchable is not None:
+            self.matchable = as_bool(data.get("matchable"))
+        else:
+            self.matchable = self.type.matchable
 
         #: If the property is of type ``entity``, the set of valid schema to be added
         #: in this property can be constrained. For example, an asset can be owned,

--- a/followthemoney/schema/Address.yaml
+++ b/followthemoney/schema/Address.yaml
@@ -22,7 +22,7 @@ Address:
     - Interval
   description: >
     A location associated with an entity.
-  matchable: false
+  matchable: true
   generated: true
   featured:
     - full


### PR DESCRIPTION
This allows deduping of address objects. Would not show up in the Aleph UI since addresses are not generated anywhere, but very useful functionality. 