### PR TITLE
Idea: transform values via python modules in mapping

### DIFF
--- a/followthemoney/util.py
+++ b/followthemoney/util.py
@@ -1,11 +1,12 @@
 import os
 import logging
 from hashlib import sha1
+from importlib import import_module
 from babel import Locale  # type: ignore
 from gettext import translation
 
 from threading import local
-from typing import cast, Dict, Any, List, Optional, TypeVar, Union, Sequence
+from typing import cast, Callable, Dict, Any, List, Optional, TypeVar, Union, Sequence
 from normality import stringify
 from normality.cleaning import compose_nfc
 from normality.cleaning import remove_unsafe_chars
@@ -149,3 +150,12 @@ def shortest(*texts: str) -> str:
 
 def longest(*texts: str) -> str:
     return max(texts, key=len)
+
+
+def import_method(method_name: str) -> Callable:
+    sep = "."
+    if ":" in method_name:
+        sep = ":"
+    package, method = method_name.rsplit(sep, 1)
+    module = import_module(package)
+    return getattr(module, method)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -230,3 +230,27 @@ class MappingTestCase(TestCase):
         self.assertCountEqual(
             entities[0].get("notes"), ["brown", "black", "blue"]
         )  # noqa
+
+    def test_mapping_apply_func(self):
+        url = "file://" + os.path.join(self.fixture_path, "links.csv")
+        mapping = {
+            "csv_url": url,
+            "entities": {
+                "director": {
+                    "schema": "Person",
+                    "key": "id",
+                    "key_literal": "person",
+                    "properties": {
+                        "name": {"column": "name"},
+                        "weakAlias": {
+                            "column": "name",
+                            "apply_func": "fingerprints.generate",
+                        },
+                    },
+                }
+            },
+        }
+
+        entities = list(model.map_entities(mapping))
+        assert len(entities) == 1, len(entities)
+        self.assertEqual(entities[0].get("weakAlias"), ["coyote e wile"])  # noqa

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from followthemoney.util import merge_context, join_text
+from followthemoney.util import merge_context, join_text, import_method
 
 
 class UtilTestCase(TestCase):
@@ -29,3 +29,11 @@ class UtilTestCase(TestCase):
         assert text == "hello 3"
         text = join_text("hello", None, 3, sep="-")
         assert text == "hello-3"
+
+    def test_import_method(self):
+        from datetime import date
+
+        self.assertEqual(date, import_method("datetime.date"))
+        self.assertEqual(
+            import_method, import_method("followthemoney.util:import_method")
+        )


### PR DESCRIPTION
```yaml
name:
  column: "name"
  apply_func: "fingerprints.generate"
```

```yaml
website:
  column: "url"
  apply_func: "myproject.cleaners:url"
```


This is a mvp draft, I just want to ask, does it make sense for you to develop this further?
Of course a proper implementation would need some safety checks for the python module import and so on...

In general, I'd love a feature like this ;)

On the other hand, one could argue that tasks like this should be done in data cleaning before applying a mapping.