### PR TITLE
Make Address a Thing

### DIFF
--- a/followthemoney/schema/Address.yaml
+++ b/followthemoney/schema/Address.yaml
@@ -19,7 +19,7 @@ Address:
   label: Address
   plural: Addresses
   extends:
-    - Interval
+    - Thing
   description: >
     A location associated with an entity.
   matchable: true


### PR DESCRIPTION
Based on feedback from @ozhyrenkov here's a change to make an Address a Thing. Note that Address (in its common usage) does not describe the presence of another thing at this address, merely the concept of a place. We may need to sooner or later introduce an Address-to-Thing interval to say: "This company was headquartered at this Address from X to Y"....