### PR TITLE
Add temporal coverage metadata

### DIFF
--- a/docs/_templates/model.jinja2
+++ b/docs/_templates/model.jinja2
@@ -105,4 +105,24 @@ to generate entities.
         see :py:attr:`followthemoney.schema.Schema.featured`
     {%- endif %}
 
+    {% if schema.temporal_start -%}
+    .. option:: Temporal start:
+
+        {% for property in schema.temporal_start -%}
+            ``{{property}}``{% if not loop.last %}{{', '}}{% endif %}
+        {%- endfor %}
+
+        see :py:attr:`followthemoney.schema.Schema.temporal_start_props`
+    {%- endif %}
+
+    {% if schema.temporal_end -%}
+    .. option:: Temporal end:
+
+        {% for property in schema.temporal_end -%}
+            ``{{property}}``{% if not loop.last %}{{', '}}{% endif %}
+        {%- endfor %}
+
+        see :py:attr:`followthemoney.schema.Schema.temporal_end_props`
+    {%- endif %}
+
 {% endfor %}

--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -330,26 +330,28 @@ class EntityProxy(object):
         return self.get_type_values(registry.country)
 
     @property
-    def temporal_start(self) -> Optional[str]:
+    def temporal_start(self) -> Optional[Tuple[Property, str]]:
         """Get a date that can be used to represent the start of the entity in a timeline.
         If there are multiple possible dates, the earliest date is returned."""
         values = []
 
         for prop in self.schema.temporal_start_props:
-            values += self.get(prop.name)
+            values += [(prop, value) for value in self.get(prop.name)]
 
-        return next(iter(sorted(values)), None)
+        values.sort(key=lambda tuple: tuple[1])
+        return next(iter(values), None)
 
     @property
-    def temporal_end(self) -> Optional[str]:
+    def temporal_end(self) -> Optional[Tuple[Property, str]]:
         """Get a date that can be used to represent the end of the entity in a timeline.
         If therer are multiple possible dates, the latest date is returned."""
         values = []
 
         for prop in self.schema.temporal_end_props:
-            values += self.get(prop)
+            values += [(prop, value) for value in self.get(prop.name)]
 
-        return next(iter(sorted(values, reverse=True)), None)
+        values.sort(reverse=True, key=lambda tuple: tuple[1])
+        return next(iter(values), None)
 
     def get_type_inverted(self, matchable: bool = False) -> Dict[str, List[str]]:
         """Return all the values of the entity arranged into a mapping with the

--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -329,6 +329,28 @@ class EntityProxy(object):
         """Get the set of all country-type values set of the entity."""
         return self.get_type_values(registry.country)
 
+    @property
+    def temporal_start(self) -> Optional[str]:
+        """Get a date that can be used to represent the start of the entity in a timeline.
+        If there are multiple possible dates, the earliest date is returned."""
+        values = []
+
+        for prop in self.schema.temporal_start_props:
+            values += self.get(prop.name)
+
+        return next(iter(sorted(values)), None)
+
+    @property
+    def temporal_end(self) -> Optional[str]:
+        """Get a date that can be used to represent the end of the entity in a timeline.
+        If therer are multiple possible dates, the latest date is returned."""
+        values = []
+
+        for prop in self.schema.temporal_end_props:
+            values += self.get(prop)
+
+        return next(iter(sorted(values, reverse=True)), None)
+
     def get_type_inverted(self, matchable: bool = False) -> Dict[str, List[str]]:
         """Return all the values of the entity arranged into a mapping with the
         group name of their property type. These groups include ``countries``,

--- a/followthemoney/schema.py
+++ b/followthemoney/schema.py
@@ -396,8 +396,8 @@ class Schema:
         end_props = [prop.name for prop in self.temporal_end_props if prop.schema == self]
         if start_props or end_props:
             data["temporalExtent"] = {
-                "start": start_props,
-                "end": end_props,
+                "start": sorted(start_props),
+                "end": sorted(end_props),
             }
         if len(self.featured):
             data["featured"] = self.featured

--- a/followthemoney/schema.py
+++ b/followthemoney/schema.py
@@ -29,6 +29,11 @@ class EdgeSpec(TypedDict, total=False):
     directed: bool
 
 
+class TemporalExtentSpec(TypedDict, total=False):
+    start: List[str]
+    end: List[str]
+
+
 class SchemaSpec(TypedDict, total=False):
     label: str
     plural: str
@@ -39,6 +44,7 @@ class SchemaSpec(TypedDict, total=False):
     required: List[str]
     caption: List[str]
     edge: EdgeSpec
+    temporalExtent: TemporalExtentSpec
     description: Optional[str]
     rdf: Optional[str]
     abstract: bool
@@ -57,6 +63,7 @@ class SchemaToDict(TypedDict, total=False):
     required: List[str]
     caption: List[str]
     edge: EdgeSpec
+    temporalExtent: TemporalExtentSpec
     description: Optional[str]
     abstract: bool
     hidden: bool
@@ -94,6 +101,8 @@ class Schema:
         "edge_source",
         "edge_target",
         "edge_caption",
+        "temporal_start",
+        "temporal_end",
         "_extends",
         "extends",
         "schemata",
@@ -164,6 +173,11 @@ class Schema:
         #: by showing an error at the target end of the edge.
         self.edge_directed = as_bool(edge.get("directed", True))
 
+        #: Specify which properties should be used to represent this schema in a timeline.
+        temporal_extent = data.get("temporalExtent", {})
+        self.temporal_start = set(temporal_extent.get("start", []))
+        self.temporal_end = set(temporal_extent.get("end", []))
+
         #: Direct parent schemata of this schema.
         self._extends = ensure_list(data.get("extends", []))
         self.extends: Set["Schema"] = set()
@@ -203,6 +217,9 @@ class Schema:
                 self.schemata.add(ancestor)
                 self.names.add(ancestor.name)
                 ancestor.descendants.add(self)
+
+            self.temporal_start |= parent.temporal_start
+            self.temporal_end |= parent.temporal_end
 
         for prop in list(self.properties.values()):
             prop.generate()
@@ -280,6 +297,18 @@ class Schema:
     def target_prop(self) -> Optional[Property]:
         """The entity property to be used as an edge target."""
         return self.get(self.edge_target)
+
+    @property
+    def temporal_start_props(self) -> Set[Property]:
+        """The entity properties to be used as the start when representing the entity in a timeline."""
+        props = [self.get(prop_name) for prop_name in self.temporal_start]
+        return set([prop for prop in props if prop is not None])
+
+    @property
+    def temporal_end_props(self) -> Set[Property]:
+        """The entity properties to be used as the end when representing the entity in a timeline."""
+        props = [self.get(prop_name) for prop_name in self.temporal_end]
+        return set([prop for prop in props if prop is not None])
 
     @property
     def sorted_properties(self) -> List[Property]:
@@ -362,6 +391,13 @@ class Schema:
                 "caption": self.edge_caption,
                 "label": self.edge_label,
                 "directed": self.edge_directed,
+            }
+        start_props = [prop.name for prop in self.temporal_start_props if prop.schema == self]
+        end_props = [prop.name for prop in self.temporal_end_props if prop.schema == self]
+        if start_props or end_props:
+            data["temporalExtent"] = {
+                "start": start_props,
+                "end": end_props,
             }
         if len(self.featured):
             data["featured"] = self.featured

--- a/followthemoney/schema/Assessment.yaml
+++ b/followthemoney/schema/Assessment.yaml
@@ -12,6 +12,9 @@ Assessment:
     - name
   required:
     - name
+  temporalExtent:
+    start:
+      - publishDate
   properties:
     publishDate:
       label: "Date of publishing"

--- a/followthemoney/schema/Contract.yaml
+++ b/followthemoney/schema/Contract.yaml
@@ -17,6 +17,9 @@ Contract:
     - title
     - name
     - procedureNumber
+  temporalExtent:
+    start:
+      - contractDate
   properties:
     title:
       label: "Contract title"

--- a/followthemoney/schema/CourtCase.yaml
+++ b/followthemoney/schema/CourtCase.yaml
@@ -12,6 +12,11 @@ CourtCase:
   caption:
     - name
     - caseNumber
+  temporalExtent:
+    start:
+      - fileDate
+    end:
+      - closeDate
   properties:
     category:
       label: Category

--- a/followthemoney/schema/CryptoWallet.yaml
+++ b/followthemoney/schema/CryptoWallet.yaml
@@ -15,6 +15,9 @@ CryptoWallet:
     - publicKey
     - name
     - summary
+  temporalExtent:
+    start:
+      - creationDate
   properties:
     publicKey:
       label: Address

--- a/followthemoney/schema/Document.yaml
+++ b/followthemoney/schema/Document.yaml
@@ -16,6 +16,11 @@ Document:
   caption:
     - fileName
     - title
+  temporalExtent:
+    start:
+      - date
+      - authoredAt
+      - publishedAt
   properties:
     contentHash:
       label: "Checksum"

--- a/followthemoney/schema/Interval.yaml
+++ b/followthemoney/schema/Interval.yaml
@@ -14,6 +14,13 @@ Interval:
     An object which is bounded in time.
   matchable: false
   abstract: true
+  temporalExtent:
+    start:
+      - startDate
+      - date
+    end:
+      - endDate
+      - date
   properties:
     startDate:
       label: "Start date"

--- a/followthemoney/schema/Interval.yaml
+++ b/followthemoney/schema/Interval.yaml
@@ -20,7 +20,6 @@ Interval:
       - date
     end:
       - endDate
-      - date
   properties:
     startDate:
       label: "Start date"

--- a/followthemoney/schema/LegalEntity.yaml
+++ b/followthemoney/schema/LegalEntity.yaml
@@ -19,6 +19,11 @@ LegalEntity:
     - email
     - phone
     - registrationNumber
+  temporalExtent:
+    start:
+      - incorporationDate
+    end:
+      - dissolutionDate
   properties:
     email:
       label: E-Mail

--- a/followthemoney/schema/Person.yaml
+++ b/followthemoney/schema/Person.yaml
@@ -17,6 +17,11 @@ Person:
     - lastName
     - email
     - phone
+  temporalExtent:
+    start:
+      - birthDate
+    end:
+      - deathDate
   properties:
     title:
       label: Title

--- a/followthemoney/schema/Security.yaml
+++ b/followthemoney/schema/Security.yaml
@@ -13,6 +13,11 @@ Security:
     - name
     - isin
     - registrationNumber
+  temporalExtent:
+    start:
+      - issueDate
+    end:
+      - maturityDate
   properties:
     isin:
       label: ISIN

--- a/followthemoney/schema/Vehicle.yaml
+++ b/followthemoney/schema/Vehicle.yaml
@@ -12,6 +12,10 @@ Vehicle:
   caption:
     - name
     - registrationNumber
+  temporalExtent:
+    start:
+      - buildDate
+      - registrationDate
   properties:
     registrationNumber:
       label: Registration number

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -344,7 +344,13 @@
       "schemata": [
         "Assessment",
         "Thing"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "publishDate"
+        ]
+      }
     },
     "Asset": {
       "caption": [
@@ -1274,7 +1280,13 @@
         "Contract",
         "Thing",
         "Value"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "contractDate"
+        ]
+      }
     },
     "ContractAward": {
       "description": "A contract or contract lot as awarded to a supplier.",
@@ -1464,7 +1476,15 @@
       "schemata": [
         "CourtCase",
         "Thing"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [
+          "closeDate"
+        ],
+        "start": [
+          "fileDate"
+        ]
+      }
     },
     "CourtCaseParty": {
       "edge": {
@@ -1595,7 +1615,13 @@
         "CryptoWallet",
         "Thing",
         "Value"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "creationDate"
+        ]
+      }
     },
     "Debt": {
       "description": "A monetary debt between two parties.",
@@ -1920,7 +1946,15 @@
         "Analyzable",
         "Document",
         "Thing"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "authoredAt",
+          "date",
+          "publishedAt"
+        ]
+      }
     },
     "Documentation": {
       "description": "Links some entity to a document, which might provide further detail or  evidence regarding the entity.\n",
@@ -2812,7 +2846,16 @@
       },
       "schemata": [
         "Interval"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "date",
+          "startDate"
+        ]
+      }
     },
     "LegalEntity": {
       "caption": [
@@ -3418,7 +3461,15 @@
       "schemata": [
         "LegalEntity",
         "Thing"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [
+          "dissolutionDate"
+        ],
+        "start": [
+          "incorporationDate"
+        ]
+      }
     },
     "License": {
       "caption": [
@@ -4457,7 +4508,15 @@
         "LegalEntity",
         "Person",
         "Thing"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [
+          "deathDate"
+        ],
+        "start": [
+          "birthDate"
+        ]
+      }
     },
     "PlainText": {
       "caption": [
@@ -4955,7 +5014,8 @@
     "Security": {
       "caption": [
         "name",
-        "isin"
+        "isin",
+        "registrationNumber"
       ],
       "description": "A tradeable financial asset.",
       "extends": [
@@ -5007,6 +5067,20 @@
           "reverse": "securities",
           "type": "entity"
         },
+        "maturityDate": {
+          "label": "Maturity date",
+          "matchable": true,
+          "name": "maturityDate",
+          "qname": "Security:maturityDate",
+          "type": "date"
+        },
+        "registrationNumber": {
+          "label": "Registration number",
+          "matchable": true,
+          "name": "registrationNumber",
+          "qname": "Security:registrationNumber",
+          "type": "identifier"
+        },
         "ticker": {
           "label": "Ticker",
           "matchable": true,
@@ -5026,7 +5100,15 @@
         "Security",
         "Thing",
         "Value"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [
+          "maturityDate"
+        ],
+        "start": [
+          "issueDate"
+        ]
+      }
     },
     "Similar": {
       "caption": [
@@ -5851,7 +5933,14 @@
         "Thing",
         "Value",
         "Vehicle"
-      ]
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "buildDate",
+          "registrationDate"
+        ]
+      }
     },
     "Vessel": {
       "caption": [

--- a/js/src/entity.ts
+++ b/js/src/entity.ts
@@ -149,30 +149,46 @@ export class Entity {
    * Get a date that can be used to represent the start of the entity in a timeline.
    * If there are multiple possible dates, the earliest date is returned.
    */
-  getTemporalStart(): Value|null {
+  getTemporalStart(): { property: Property, value: Value }|null {
     const values = [];
     const properties = this.schema.getTemporalStartProperties();
 
     for (const property of properties) {
-      values.push(...this.getProperty(property));
+      values.push(
+        ...this.getProperty(property).map(
+          (value) => ({ property, value})
+        )
+      );
     }
 
-    return values.sort()[0] || null;
+    const sortedValues = values.sort(
+      (a, b) => a.value < b.value ? -1 : 1
+    );
+
+    return sortedValues[0] || null;
   }
 
   /** 
    * Get a date that can be used to represent the end of the entity in a timeline.
    * If there are multiple possible dates, the earliest date is returned.
    */
-  getTemporalEnd(): Value|null {
+  getTemporalEnd(): { property: Property, value: Value }|null {
     const values = [];
     const properties = this.schema.getTemporalEndProperties();
 
     for (const property of properties) {
-      values.push(...this.getProperty(property));
+      values.push(
+        ...this.getProperty(property).map(
+          (value) => ({ property, value })
+        )
+      );
     }
 
-    return values.sort().slice(-1)[0] || null;
+    const sortedValues = values.sort(
+      (a, b) => b.value < a.value ? -1 : 1
+    );
+
+    return sortedValues[0] || null;
   }
 
   /**

--- a/js/src/entity.ts
+++ b/js/src/entity.ts
@@ -149,16 +149,16 @@ export class Entity {
    * Get a date that can be used to represent the start of the entity in a timeline.
    * If there are multiple possible dates, the earliest date is returned.
    */
-  getTemporalStart(): { property: Property, value: Value } | null {
+  getTemporalStart(): { property: Property, value: string } | null {
     const values = []
     const properties = this.schema.getTemporalStartProperties()
 
     for (const property of properties) {
-      values.push(
-        ...this.getProperty(property).map(
-          (value) => ({ property, value})
-        )
-      )
+      for (const value of this.getProperty(property)) {
+        if (typeof value === 'string') {
+          values.push({ property, value })
+        }
+      }
     }
 
     const sortedValues = values.sort(
@@ -172,16 +172,16 @@ export class Entity {
    * Get a date that can be used to represent the end of the entity in a timeline.
    * If there are multiple possible dates, the earliest date is returned.
    */
-  getTemporalEnd(): { property: Property, value: Value } | null {
+  getTemporalEnd(): { property: Property, value: string } | null {
     const values = []
     const properties = this.schema.getTemporalEndProperties()
 
     for (const property of properties) {
-      values.push(
-        ...this.getProperty(property).map(
-          (value) => ({ property, value })
-        )
-      )
+      for (const value of this.getProperty(property)) {
+        if (typeof value === 'string') {
+          values.push({ property, value })
+        }
+      }
     }
 
     const sortedValues = values.sort(

--- a/js/src/entity.ts
+++ b/js/src/entity.ts
@@ -149,46 +149,46 @@ export class Entity {
    * Get a date that can be used to represent the start of the entity in a timeline.
    * If there are multiple possible dates, the earliest date is returned.
    */
-  getTemporalStart(): { property: Property, value: Value }|null {
-    const values = [];
-    const properties = this.schema.getTemporalStartProperties();
+  getTemporalStart(): { property: Property, value: Value } | null {
+    const values = []
+    const properties = this.schema.getTemporalStartProperties()
 
     for (const property of properties) {
       values.push(
         ...this.getProperty(property).map(
           (value) => ({ property, value})
         )
-      );
+      )
     }
 
     const sortedValues = values.sort(
       (a, b) => a.value < b.value ? -1 : 1
-    );
+    )
 
-    return sortedValues[0] || null;
+    return sortedValues[0] || null
   }
 
   /** 
    * Get a date that can be used to represent the end of the entity in a timeline.
    * If there are multiple possible dates, the earliest date is returned.
    */
-  getTemporalEnd(): { property: Property, value: Value }|null {
-    const values = [];
-    const properties = this.schema.getTemporalEndProperties();
+  getTemporalEnd(): { property: Property, value: Value } | null {
+    const values = []
+    const properties = this.schema.getTemporalEndProperties()
 
     for (const property of properties) {
       values.push(
         ...this.getProperty(property).map(
           (value) => ({ property, value })
         )
-      );
+      )
     }
 
     const sortedValues = values.sort(
       (a, b) => b.value < a.value ? -1 : 1
-    );
+    )
 
-    return sortedValues[0] || null;
+    return sortedValues[0] || null
   }
 
   /**

--- a/js/src/entity.ts
+++ b/js/src/entity.ts
@@ -146,6 +146,36 @@ export class Entity {
   }
 
   /**
+   * Get a date that can be used to represent the start of the entity in a timeline.
+   * If there are multiple possible dates, the earliest date is returned.
+   */
+  getTemporalStart(): Value|null {
+    const values = [];
+    const properties = this.schema.getTemporalStartProperties();
+
+    for (const property of properties) {
+      values.push(...this.getProperty(property));
+    }
+
+    return values.sort()[0] || null;
+  }
+
+  /** 
+   * Get a date that can be used to represent the end of the entity in a timeline.
+   * If there are multiple possible dates, the earliest date is returned.
+   */
+  getTemporalEnd(): Value|null {
+    const values = [];
+    const properties = this.schema.getTemporalEndProperties();
+
+    for (const property of properties) {
+      values.push(...this.getProperty(property));
+    }
+
+    return values.sort().slice(-1)[0] || null;
+  }
+
+  /**
    * Get all the values of a particular type, irrespective of
    * which property it is associated with.
    */

--- a/js/src/schema.ts
+++ b/js/src/schema.ts
@@ -145,25 +145,27 @@ export class Schema {
   }
 
   getTemporalStartProperties(): Array<Property> {
-    const properties: Array<Property> = this.temporalStart
-      .map(name => this.getProperty(name))
+    const properties: Set<string> = new Set(this.temporalStart);
 
     for (const ext of this.getExtends()) {
-      properties.push(...ext.getTemporalStartProperties())
+      for (const property of ext.getTemporalStartProperties()) {
+        properties.add(property.name);
+      }
     }
 
-    return properties
+    return Array.from(properties).map((name) => this.getProperty(name));
   }
 
   getTemporalEndProperties(): Array<Property> {
-    const properties: Array<Property> = this.temporalEnd
-      .map(name => this.getProperty(name))
+    const properties: Set<string> = new Set(this.temporalEnd);
 
     for (const ext of this.getExtends()) {
-      properties.push(...ext.getTemporalEndProperties())
+      for (const property of ext.getTemporalEndProperties()) {
+        properties.add(property.name);
+      }
     }
 
-    return properties
+    return Array.from(properties).map((name) => this.getProperty(name));
   }
 
   hasProperty(prop: string | Property): boolean {

--- a/js/test/entity.test.ts
+++ b/js/test/entity.test.ts
@@ -92,19 +92,15 @@ describe('ftm/Entity class', () => {
         id: '1',
         schema: 'Event',
         properties: {
-          startDate: ['2022-01-01'],
-        },
-      })
-      expect(entity.getTemporalStart()).toEqual('2022-01-01')
-
-      entity = model.getEntity({
-        id: '1',
-        schema: 'Event',
-        properties: {
           startDate: ['2022-01-01', '2022-02-01'],
+          date: ['2022-03-01'],
         },
       })
-      expect(entity.getTemporalStart()).toEqual('2022-01-01')
+
+      const start = entity.getTemporalStart()
+      expect(start).not.toBeNull()
+      expect(start!.property).toEqual(entity.schema.getProperty('startDate'))
+      expect(start!.value).toEqual('2022-01-01')
     })
     it('can get temporal end', function () {
       let entity;
@@ -116,19 +112,14 @@ describe('ftm/Entity class', () => {
         id: '1',
         schema: 'Event',
         properties: {
-          endDate: ['2022-02-01'],
+          endDate: ['2022-02-01', '2022-01-01'],
         },
       })
-      expect(entity.getTemporalEnd()).toEqual('2022-02-01')
 
-      entity = model.getEntity({
-        id: '1',
-        schema: 'Event',
-        properties: {
-          endDate: ['2022-01-01', '2022-02-01'],
-        },
-      })
-      expect(entity.getTemporalEnd()).toEqual('2022-02-01')
+      const end = entity.getTemporalEnd()
+      expect(end).not.toBeNull()
+      expect(end!.property).toEqual(entity.schema.getProperty('endDate'))
+      expect(end!.value).toEqual('2022-02-01')
     })
   })
 })

--- a/js/test/entity.test.ts
+++ b/js/test/entity.test.ts
@@ -83,7 +83,7 @@ describe('ftm/Entity class', () => {
       expect(passport.getCaption()).toBe(testNumber)
     })
     it('can get temporal start', function() {
-      let entity;
+      let entity
 
       entity = model.getEntity({ id: '1', schema: 'Event' })
       expect(entity.getTemporalStart()).toBeNull()
@@ -103,7 +103,7 @@ describe('ftm/Entity class', () => {
       expect(start!.value).toEqual('2022-01-01')
     })
     it('can get temporal end', function () {
-      let entity;
+      let entity
 
       entity = model.getEntity({ id: '1', schema: 'Event' })
       expect(entity.getTemporalEnd()).toBeNull()

--- a/js/test/entity.test.ts
+++ b/js/test/entity.test.ts
@@ -82,5 +82,53 @@ describe('ftm/Entity class', () => {
       passport.setCaption(testNumber)
       expect(passport.getCaption()).toBe(testNumber)
     })
+    it('can get temporal start', function() {
+      let entity;
+
+      entity = model.getEntity({ id: '1', schema: 'Event' })
+      expect(entity.getTemporalStart()).toBeNull()
+
+      entity = model.getEntity({
+        id: '1',
+        schema: 'Event',
+        properties: {
+          startDate: ['2022-01-01'],
+        },
+      })
+      expect(entity.getTemporalStart()).toEqual('2022-01-01')
+
+      entity = model.getEntity({
+        id: '1',
+        schema: 'Event',
+        properties: {
+          startDate: ['2022-01-01', '2022-02-01'],
+        },
+      })
+      expect(entity.getTemporalStart()).toEqual('2022-01-01')
+    })
+    it('can get temporal end', function () {
+      let entity;
+
+      entity = model.getEntity({ id: '1', schema: 'Event' })
+      expect(entity.getTemporalEnd()).toBeNull()
+
+      entity = model.getEntity({
+        id: '1',
+        schema: 'Event',
+        properties: {
+          endDate: ['2022-02-01'],
+        },
+      })
+      expect(entity.getTemporalEnd()).toEqual('2022-02-01')
+
+      entity = model.getEntity({
+        id: '1',
+        schema: 'Event',
+        properties: {
+          endDate: ['2022-01-01', '2022-02-01'],
+        },
+      })
+      expect(entity.getTemporalEnd()).toEqual('2022-02-01')
+    })
   })
 })

--- a/js/test/schema.test.ts
+++ b/js/test/schema.test.ts
@@ -125,4 +125,40 @@ describe('ftm/Schema class', () => {
       expect(children).toContain('Company')
     })
   })
+  describe('method getTemporalStartProperties', () => {
+    it('returns empty array if not specified', () => {
+      const thing = model.getSchema('Thing')
+      expect(thing.getTemporalStartProperties()).toEqual([])
+    })
+
+    it('returns array of properties', () => {
+      const interval = model.getSchema('Interval')
+      const props = interval.getTemporalStartProperties()
+      expect(new Set(props.map(prop => prop.name))).toEqual(new Set(['startDate', 'date']))
+    })
+
+    it('inherits properties', () => {
+      const event = model.getSchema('Event')
+      const props = event.getTemporalStartProperties()
+      expect(new Set(props.map(prop => prop.name))).toEqual(new Set(['startDate', 'date']))
+    })
+  })
+  describe('method getTemporalEndProperties', () => {
+    it('returns empty array if not specified', () => {
+      const thing = model.getSchema('Thing')
+      expect(thing.getTemporalEndProperties()).toEqual([])
+    })
+
+    it('returns array of properties', () => {
+      const interval = model.getSchema('Interval')
+      const props = interval.getTemporalEndProperties()
+      expect(new Set(props.map(prop => prop.name))).toEqual(new Set(['endDate']))
+    })
+
+    it('inherits properties', () => {
+      const event = model.getSchema('Event')
+      const props = event.getTemporalEndProperties()
+      expect(new Set(props.map(prop => prop.name))).toEqual(new Set(['endDate']))
+    })
+  })
 })

--- a/js/test/schema.test.ts
+++ b/js/test/schema.test.ts
@@ -134,13 +134,13 @@ describe('ftm/Schema class', () => {
     it('returns array of properties', () => {
       const interval = model.getSchema('Interval')
       const props = interval.getTemporalStartProperties()
-      expect(new Set(props.map(prop => prop.name))).toEqual(new Set(['startDate', 'date']))
+      expect(props.map(prop => prop.name)).toEqual(['date', 'startDate'])
     })
 
     it('inherits properties', () => {
       const event = model.getSchema('Event')
       const props = event.getTemporalStartProperties()
-      expect(new Set(props.map(prop => prop.name))).toEqual(new Set(['startDate', 'date']))
+      expect(props.map(prop => prop.name)).toEqual(['date', 'startDate'])
     })
   })
   describe('method getTemporalEndProperties', () => {
@@ -152,13 +152,13 @@ describe('ftm/Schema class', () => {
     it('returns array of properties', () => {
       const interval = model.getSchema('Interval')
       const props = interval.getTemporalEndProperties()
-      expect(new Set(props.map(prop => prop.name))).toEqual(new Set(['endDate']))
+      expect(props.map(prop => prop.name)).toEqual(['endDate'])
     })
 
     it('inherits properties', () => {
       const event = model.getSchema('Event')
       const props = event.getTemporalEndProperties()
-      expect(new Set(props.map(prop => prop.name))).toEqual(new Set(['endDate']))
+      expect(props.map(prop => prop.name)).toEqual(['endDate'])
     })
   })
 })

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -176,3 +176,27 @@ class ModelTestCase(TestCase):
 
         sprops = list(directorship.sorted_properties)
         assert len(sprops) == len(directorship.properties), sprops
+
+    def test_schema_temporal_extent(self):
+        interval = model.schemata["Interval"]
+        event = model.schemata["Event"]
+
+        assert interval.temporal_start == set(["startDate", "date"])
+        assert interval.temporal_end == set(["endDate"])
+        assert interval.temporal_start_props == set([
+            interval.get("startDate"),
+            interval.get("date"),
+        ])
+        assert interval.temporal_end_props == set([
+            interval.get("endDate"),
+        ])
+
+        assert event.temporal_start == set(["startDate", "date"])
+        assert event.temporal_end == set(["endDate"])
+        assert interval.temporal_start_props == set([
+            interval.get("startDate"),
+            interval.get("date"),
+        ])
+        assert interval.temporal_end_props == set([
+            interval.get("endDate"),
+        ])

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -235,9 +235,14 @@ class ProxyTestCase(TestCase):
             "schema": "Event",
             "properties": {
                 "startDate": ["2022-01-01", "2022-02-01"],
+                "date": ["2022-03-01"],
             }
         })
-        assert proxy.temporal_start == "2022-01-01"
+
+        assert proxy.temporal_start is not None
+        prop, value = proxy.temporal_start
+        assert prop == proxy.schema.get('startDate')
+        assert value == ("2022-01-01")
 
     def test_temporal_end(self):
         proxy = EntityProxy.from_dict(model, {"schema": "Event"})
@@ -249,4 +254,8 @@ class ProxyTestCase(TestCase):
                 "endDate": ["2022-01-01", "2022-02-01"],
             }
         })
-        assert proxy.temporal_end == "2022-02-01"
+
+        assert proxy.temporal_end is not None
+        prop, value = proxy.temporal_end
+        assert prop == proxy.schema.get('endDate')
+        assert value == "2022-02-01"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -226,3 +226,27 @@ class ProxyTestCase(TestCase):
 
         proxy = model.make_entity("Person")
         assert 0 == len(list(proxy.triples()))
+
+    def test_temporal_start(self):
+        proxy = model.get_proxy({"schema": "Event"})
+        assert proxy.temporal_start is None
+
+        proxy = model.get_proxy({
+            "schema": "Event",
+            "properties": {
+                "startDate": ["2022-01-01", "2022-02-01"],
+            }
+        })
+        assert proxy.temporal_start == "2022-01-01"
+
+    def test_temporal_end(self):
+        proxy = EntityProxy.from_dict(model, {"schema": "Event"})
+        assert proxy.temporal_start is None
+
+        proxy = EntityProxy.from_dict(model, {
+            "schema": "Event",
+            "properties": {
+                "endDate": ["2022-01-01", "2022-02-01"],
+            }
+        })
+        assert proxy.temporal_end == "2022-02-01"


### PR DESCRIPTION
This adds basic support for temporal extent metadata (#811) to the Python and TS libraries. It also adds helpers to entity proxies to retrieve the temporal start and end:

```python
company = model.make_entity('Company')
company.add('incorporationDate', '2021-01-01')
company.add('dissolutionDate', '2021-12-31')
company.temporal_start # '2021-01-01'
company.temporal_end # '2021-12-31'

event = model.make_entity('Event')
event.add('date', 2022-01-01')
company.temporal_start # '2021-01-01'
company.temporal_end # None
```

```ts
const company = model.createEntity('Company');
company.setProperty('incorporationDate', '2021-01-01');
company.setProperty('dissolutionDate', '2021-12-31');
company.getTemporalStart(); // '2021-01-01'
company.getTemporalEnd(); // '2021-12-31'

const event = model.createEntity('Event');
event.setProperty('date', '2021-01-01');
event.getTemporalStart(); // '2021-01-01'
event.getTemporalEnd(); // null
```

I also added temporal extent metadata to all existing schemata (where applicable), although I’d consider this work in progress and I’ll wait for feedback from people who have real-world experience working with the model.

I added the temporal extent metadata to the schemata documentation which is [available here](https://followthemoney--849.org.readthedocs.build/en/849/model.html#event).