### PR TITLE
Sort schemata documentation alphabetically

### DIFF
--- a/docs/_templates/model.jinja2
+++ b/docs/_templates/model.jinja2
@@ -10,7 +10,7 @@ to generate entities.
 .. contents:: Schemata
     :local:
 
-{% for schema in model.schemata.values(): %}
+{% for schema in model.schemata.values() | sort(attribute='label'): %}
 .. _schema-{{schema.name}}:
 
 {{schema.label}}


### PR DESCRIPTION
Currently, schemata docs aren’t sorted in any way which makes it harder to quickly look up schemata.