### PR TITLE
Improve domain related email cleanup error handling

### DIFF
--- a/followthemoney/types/email.py
+++ b/followthemoney/types/email.py
@@ -68,7 +68,10 @@ class EmailType(PropertyType):
         domain = domain.lower()
         domain = domain.rstrip(".")
         # handle unicode
-        domain = domain.encode("idna").decode("ascii")
+        try:
+            domain = domain.encode("idna").decode("ascii")
+        except UnicodeError:
+            return None
         if domain is not None and mailbox is not None:
             return "@".join((mailbox, domain))
         return None

--- a/tests/types/test_emails.py
+++ b/tests/types/test_emails.py
@@ -16,6 +16,18 @@ class EmailsTest(unittest.TestCase):
         self.assertEqual(emails.clean(5), None)
         self.assertEqual(emails.clean("foo@PUDO.org"), "foo@pudo.org")
         self.assertEqual(emails.clean("FOO@PUDO.org"), "FOO@pudo.org")
+        self.assertEqual(
+            emails.clean(
+                "foo@0123456789012345678901234567890123456789012345678901234567890.example.com"
+            ),
+            "foo@0123456789012345678901234567890123456789012345678901234567890.example.com",
+        )
+        self.assertEqual(
+            emails.clean(
+                "foo@0123456789012345678901234567890123456789012345678901234567890123.example.com"
+            ),
+            None,
+        )
 
     def test_domain_validity(self):
         self.assertTrue(emails.validate("foo@pudo.org"))


### PR DESCRIPTION
This came up in https://github.com/alephdata/ingest-file/issues/253. The `str.encode` function may raise an `UnicodeError` which should be handled. In our case any failure to encode the domain as `idna` means the domain name can't be parsed.

Fixes #870