### PR TITLE
Add missing release step: make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ release: clean dist
 docker:
 	docker build -t alephdata/followthemoney .
 
-build: namespace default-model translate docker
+build: namespace default-model translate
 
 namespace:
 	python followthemoney/ontology.py docs/ns

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ this end, here's the steps for making a release:
 
 ```bash
 git pull --rebase
+make build
 make test
+git add . && git commit -m "Updating translation files"
 bumpversion patch
 git push --atomic origin master $(git describe --tags --abbrev=0)
 ```


### PR DESCRIPTION
It came up yesterday (https://alephdata.slack.com/archives/C042X0MJF7B/p1667407517705589?thread_ts=1667407106.560519&cid=C042X0MJF7B) that `make build` needs to be run before a release is done. 

I added a commit step for the changed translation (&other) files after we make sure the tests pass.