### PR TITLE
Schema/Address: Add osm / google places id

### DIFF
--- a/followthemoney/schema/Address.yaml
+++ b/followthemoney/schema/Address.yaml
@@ -69,3 +69,9 @@ Address:
     country:
       label: "Country"
       type: "country"
+    osmId:
+      label: "OpenStreetmap Place ID"
+      type: "identifier"
+    googlePlaceId:
+      label: "Google Places ID"
+      type: "identifier"


### PR DESCRIPTION
I remember discussions about ftm/aleph should NOT start to implement geo functionality, and I am :100: on this side.

But still, as the Address entity has lat/lon props, it would be useful for some applications to be able to add osm or google place id (as a result from a geocoding process)

I don't now if type should be an identifier?