### PR TITLE
Fixed Schema for Identification and UserAccount, as described in #952

### DIFF
--- a/followthemoney/schema/Identification.yaml
+++ b/followthemoney/schema/Identification.yaml
@@ -32,7 +32,7 @@ Identification:
       label: "Country"
       type: country
     number:
-      label: "Passport number"
+      label: "Document number"
       type: identifier
     authority:
       label: "Authority"

--- a/followthemoney/schema/UserAccount.yaml
+++ b/followthemoney/schema/UserAccount.yaml
@@ -39,3 +39,6 @@ UserAccount:
     password:
       label: "Password"
       type: string
+    ipAddress:
+      label: "IP address"
+      type: ip


### PR DESCRIPTION
1. Renamed `Identification:number` label from `Passport number`  to `Document number`.
2. Added `ipAddress` property to `UserAccount`.