### PR TITLE
Fix duplicate property label

### DIFF
--- a/followthemoney/schema/EconomicActivity.yaml
+++ b/followthemoney/schema/EconomicActivity.yaml
@@ -44,8 +44,7 @@ EconomicActivity:
       label: "FEAC Code description"
       description: "(Описание кода ТН ВЭД) Foreign Economic Activity Commodity Code description"
     goodsDescription:
-      label: "Description"
-      description: "Description of goods"
+      label: "Description of goods"
       type: text
     declarant:
       label: "Declarant"


### PR DESCRIPTION
`EconomicActivity` inherits the `Interval:description` property (labeled "Description") and also defines its own `goodsDescription` property (also labeled "Description"). This leads to confusion when displaying lists of properties in user interfaces.

We may want to reconsider if a separate `goodsDescription` property is necessary. However, this would be a breaking change, so for now I suggest we update the label to be unique.