### PR TITLE
Add opening/closing date to `BankAccount` schema

### DIFF
--- a/followthemoney/schema/BankAccount.yaml
+++ b/followthemoney/schema/BankAccount.yaml
@@ -36,6 +36,12 @@ BankAccount:
         label: "Bank accounts"
     accountType:
       label: Account type
+    openingDate:
+      label: Opening date
+      type: date
+    closingDate:
+      label: Closing date
+      type: date
     balance:
       label: Balance
       type: number


### PR DESCRIPTION
Closes #809

A common use case for timelines is finding correlations between company registrations, bank accounts, shareholder and ownership changes etc. Currently, there is no way to add an opening/dissolution date to `BankAccount` entities.