### PR TITLE
Fix levensthein segmentation fault in invalid name picking

### DIFF
--- a/followthemoney/types/name.py
+++ b/followthemoney/types/name.py
@@ -1,8 +1,8 @@
-from typing import Dict, List, Optional, Sequence, TYPE_CHECKING, Union
-from banal import first
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union
+
+from Levenshtein import distance, setmedian
 from normality import slugify
 from normality.cleaning import collapse_spaces, strip_quotes
-from Levenshtein import distance, setmedian
 
 from followthemoney.types.common import PropertyType
 from followthemoney.util import dampen
@@ -56,6 +56,9 @@ class NameType(PropertyType):
             normalised.append(norm)
             lookup.setdefault(norm, [])
             lookup[norm].append(value)
+
+        if not normalised:
+            return None
 
         norm = setmedian(normalised)
         if norm is None:

--- a/tests/types/test_names.py
+++ b/tests/types/test_names.py
@@ -22,6 +22,12 @@ class NamesTest(unittest.TestCase):
         values = ["Robert Smith", "Rob Smith", "Robert SMITH"]
         self.assertEqual(names.pick(values), "Robert SMITH")
 
+        # handle dirty edgecases
+        values = ["", "(", "Peter"]
+        self.assertEqual(names.pick(values), "Peter")
+        values = ["", "("]
+        self.assertEqual(names.pick(values), None)
+
     def test_domain_validity(self):
         self.assertTrue(names.validate("huhu"))
         self.assertFalse(names.validate(""))


### PR DESCRIPTION
when the `pick` function for `registry.name` receives only "non-name" values, like "-", "(" (which can happen in dirty real world data), the normalized values list is empty which creates (at least on linux, python 3.11) a segmentation fault:

```python
Python 3.11.2 (main, Feb 12 2023, 00:48:52) [GCC 12.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.10.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from Levenshtein import setmedian

In [2]: setmedian([])
[1]    307409 segmentation fault  ipython
```

In this fix we would return `None` for this case (as seen for other cases in the same function.)