### PR TITLE
Change type of `Contract:classification` to `string`

### DIFF
--- a/followthemoney/schema/Contract.yaml
+++ b/followthemoney/schema/Contract.yaml
@@ -62,7 +62,6 @@ Contract:
       label: Contract award criteria
     classification:
       label: Classification
-      type: text
     cancelled:
       label: "Cancelled?"
     language:


### PR DESCRIPTION
`LegalEntity` and `Security` already define `classification` properties that use the `string` type.

The mismatch in property types has caused issues in Aleph (`string` and `text` properties are mapped to `keyword` and `text` properties in ElasticSearch which behave differently).

Alex and I spent some time today double-checking how changing FtM property types affects Aleph’s ES indexes. We were able to confirm that (as changing field types for existing indexes in ES [is not supported](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html#updating-field-mappings)) this won’t affect existing indexes until they are recreated/rebuilt, but it also doesn’t break anything.

So we should be good to go to merge these changes with regards to Aleph.