### PR TITLE
Add de-registration date property for vehicles

### DIFF
--- a/followthemoney/schema/Vehicle.yaml
+++ b/followthemoney/schema/Vehicle.yaml
@@ -16,6 +16,8 @@ Vehicle:
     start:
       - buildDate
       - registrationDate
+    end:
+      - deregistrationDate
   properties:
     registrationNumber:
       label: Registration number
@@ -43,4 +45,7 @@ Vehicle:
       type: date
     registrationDate:
       label: Registration Date
+      type: date
+    deregistrationDate:
+      label: De-registration Date
       type: date


### PR DESCRIPTION
Aircraft are sometimes deleted (366 de-registrations from the Malta registry since 2012). Add a field for the de-registration date of a vehicle for when this data point is available.