### PR TITLE
Only build/push Docker image on main branch and tagged commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU
@@ -101,7 +102,6 @@ jobs:
         run: echo "VERSION_NUMBER=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - name: Login to GitHub Packages
         uses: docker/login-action@v2
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
The docker job is currently failing on branches, because we skip the registry auth step but still try to push images.

Not sure what the intent here was: Pushing images only for main/releases or pushing images on every commit? Assuming 1) is the case?