### PR TITLE
RE:  Idea: transform values via python modules in mapping (was: #681)

### DIFF
--- a/followthemoney/util.py
+++ b/followthemoney/util.py
@@ -1,16 +1,16 @@
-import os
 import logging
-from hashlib import sha1
-from babel import Locale
+import os
 from gettext import translation
-
+from hashlib import sha1
+from importlib import import_module
 from threading import local
-from typing import cast, Dict, Any, List, Optional, TypeVar, Union, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar, Union, cast
+
+from babel import Locale  # type: ignore
+from banal import ensure_list, is_mapping, unique_list
 from normality import stringify
-from normality.cleaning import compose_nfc
-from normality.cleaning import remove_unsafe_chars
+from normality.cleaning import compose_nfc, remove_unsafe_chars
 from normality.encoding import DEFAULT_ENCODING
-from banal import is_mapping, unique_list, ensure_list
 
 MEGABYTE = 1024 * 1024
 DEFAULT_LOCALE = "en"
@@ -158,3 +158,12 @@ def shortest(*texts: str) -> str:
 
 def longest(*texts: str) -> str:
     return max(texts, key=len)
+
+
+def import_method(method_name: str) -> Callable:
+    sep = "."
+    if ":" in method_name:
+        sep = ":"
+    package, method = method_name.rsplit(sep, 1)
+    module = import_module(package)
+    return getattr(module, method)

--- a/followthemoney/util.py
+++ b/followthemoney/util.py
@@ -52,10 +52,10 @@ def get_locale() -> Locale:
     return cast(Locale, state.locale)
 
 
-def get_env_list(name: str, default: List[str] = []) -> List[str]:
+def get_env_list(name: str, default: List[str] = [], sep: str = ":") -> List[str]:
     value = stringify(os.environ.get(name))
     if value is not None:
-        values = value.split(":")
+        values = value.split(sep)
         if len(values):
             return values
     return default

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,7 +1,9 @@
 import os
-import yaml
-import responses
 from unittest import TestCase
+
+import responses
+import yaml
+
 from followthemoney import model
 from followthemoney.exc import InvalidMapping
 
@@ -251,6 +253,11 @@ class MappingTestCase(TestCase):
             },
         }
 
+        with self.assertRaises(InvalidMapping) as e:
+            entities = list(model.map_entities(mapping))
+            assert "not registered" in str(e)
+
+        os.environ["FTM_SAFE_MODULES"] = "fingerprints,datetime"
         entities = list(model.map_entities(mapping))
         assert len(entities) == 1, len(entities)
         self.assertEqual(entities[0].get("weakAlias"), ["coyote e wile"])  # noqa

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -230,3 +230,27 @@ class MappingTestCase(TestCase):
         self.assertCountEqual(
             entities[0].get("notes"), ["brown", "black", "blue"]
         )  # noqa
+
+    def test_mapping_apply_func(self):
+        url = "file://" + os.path.join(self.fixture_path, "links.csv")
+        mapping = {
+            "csv_url": url,
+            "entities": {
+                "director": {
+                    "schema": "Person",
+                    "key": "id",
+                    "key_literal": "person",
+                    "properties": {
+                        "name": {"column": "name"},
+                        "weakAlias": {
+                            "column": "name",
+                            "apply_func": "fingerprints.generate",
+                        },
+                    },
+                }
+            },
+        }
+
+        entities = list(model.map_entities(mapping))
+        assert len(entities) == 1, len(entities)
+        self.assertEqual(entities[0].get("weakAlias"), ["coyote e wile"])  # noqa

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from followthemoney.util import merge_context, join_text
+from followthemoney.util import merge_context, join_text, import_method
 
 
 class UtilTestCase(TestCase):
@@ -29,3 +29,11 @@ class UtilTestCase(TestCase):
         assert text == "hello 3"
         text = join_text("hello", None, 3, sep="-")
         assert text == "hello-3"
+
+    def test_import_method(self):
+        from datetime import date
+
+        self.assertEqual(date, import_method("datetime.date"))
+        self.assertEqual(
+            import_method, import_method("followthemoney.util:import_method")
+        )


### PR DESCRIPTION
Hey, I am currently re-considering this: https://github.com/alephdata/followthemoney/pull/681

Still find it very useful. I now added a safe guard via an env var `FTM_SAFE_MODULES` that must contain a comma-separated list of python modules that are allowed (see tests)

So, to use that as an RCE entrypoint, one has to be in control over the followthemoney deployment environment