### PR TITLE
Replace cast() with calling Locale() to ensure obj type

### DIFF
--- a/followthemoney/util.py
+++ b/followthemoney/util.py
@@ -49,7 +49,7 @@ def set_model_locale(locale: Locale) -> None:
 def get_locale() -> Locale:
     if not hasattr(state, "locale"):
         return Locale.parse(DEFAULT_LOCALE)
-    return cast(Locale, state.locale)
+    return Locale.parse(state.locale)
 
 
 def get_env_list(name: str, default: List[str] = []) -> List[str]:


### PR DESCRIPTION
Due to an assumption made in #1049 - namely, that calling `cast()` (from the `typing` module) would ensure that the return value of `get_locale()` has the correct type, `Locale` - we were seeing the following error in Aleph:

```
Traceback (most recent call last):
  File "/aleph/aleph/tests/test_base_api.py", line 16, in test_metadata
    res = self.client.get("/api/2/metadata")
  File "/usr/local/lib/python3.8/dist-packages/werkzeug/test.py", line 1242, in get
    return self.open(*args, **kw)
  File "/usr/local/lib/python3.8/dist-packages/flask/testing.py", line 219, in open
    response = super().open(
  File "/usr/local/lib/python3.8/dist-packages/werkzeug/test.py", line 1196, in open
    response = self.run_wsgi_app(request.environ, buffered=buffered)
  File "/usr/local/lib/python3.8/dist-packages/werkzeug/test.py", line 1068, in run_wsgi_app
    rv = run_wsgi_app(self.application, environ, buffered=buffered)
  File "/usr/local/lib/python3.8/dist-packages/werkzeug/test.py", line 1344, in run_wsgi_app
    app_rv = app(environ, start_response)
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2213, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2193, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.8/dist-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2190, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1486, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.8/dist-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/aleph/aleph/views/base_api.py", line 98, in metadata
    data = _metadata_locale(locale)
  File "/aleph/aleph/views/base_api.py", line 50, in _metadata_locale
    model_data = model.to_dict()
  File "/usr/local/lib/python3.8/dist-packages/followthemoney/model.py", line 148, in to_dict
    "types": {t.name: t.to_dict() for t in registry.types},
  File "/usr/local/lib/python3.8/dist-packages/followthemoney/model.py", line 148, in <dictcomp>
    "types": {t.name: t.to_dict() for t in registry.types},
  File "/usr/local/lib/python3.8/dist-packages/followthemoney/types/common.py", line 260, in to_dict
    data["values"] = self.names
  File "/usr/local/lib/python3.8/dist-packages/followthemoney/types/common.py", line 230, in names
    self._names[locale] = self._locale_names(locale)
  File "/usr/local/lib/python3.8/dist-packages/followthemoney/types/country.py", line 55, in _locale_names
    for code, label in locale.territories.items():
AttributeError: 'str' object has no attribute 'territories'
```

The current PR modifies `util.py` so that all values returned from `get_locale()` are guaranteed to be of type `Locale`. 
