### PR TITLE
Make FTM cross-compatible with SQLAlchemy 1.4 and 2+

### DIFF
--- a/followthemoney/mapping/sql.py
+++ b/followthemoney/mapping/sql.py
@@ -55,10 +55,7 @@ class SQLSource(Source):
         if database is None:
             raise InvalidMapping("No database in SQL mapping!")
         self.database_uri = cast(str, os.path.expandvars(database))
-        kwargs = {}
-        if self.database_uri.lower().startswith("postgres"):
-            kwargs["server_side_cursors"] = True
-        self.engine = create_engine(self.database_uri, poolclass=NullPool, **kwargs)  # type: ignore
+        self.engine = create_engine(self.database_uri, poolclass=NullPool)  # type: ignore
         self.meta = MetaData()
 
         tables = keys_values(data, "table", "tables")
@@ -104,7 +101,7 @@ class SQLSource(Source):
         q = self.compose_query()
         log.info("Query: %s", q)
         with self.engine.connect() as conn:
-            rp = conn.execute(q)
+            rp = conn.execution_options(stream_results=True).execute(q)
             while True:
                 rows = rp.fetchmany(size=DATA_PAGE)
                 if not len(rows):


### PR DESCRIPTION
- [ ] run the SQLAlchemy tests with a Postgres connection
- [ ] update Server Side Cursors in `sql.py` to work with SQLA 2+ ([as per the docs](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#server-side-cursors)) - current warning is: 
```
followthemoney/followthemoney/mapping/sql.py:61: SADeprecationWarning: The create_engine.server_side_cursors parameter is deprecated and will be removed in a future release.  Please use the Connection.execution_options.stream_results parameter.
    self.engine = create_engine(self.database_uri, poolclass=NullPool, **kwargs)  # type: ignore
```

- [ ] will `dataset` require a SQLAlchemy version < 1.4 in order to work? Don't merge this PR until this question is settled. Right now it seems `dataset` tests hang when run against Postgres with SQLAlchemy 1.4