### PR TITLE
Display warnings for deprecated schemata and properties

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@alephdata/followthemoney": "^3.2.1",
+        "@alephdata/followthemoney": "^3.5.1",
         "@astrojs/markdown-component": "^1.0.2",
         "astro": "^1.4.3",
         "astro-theme-docs": "github:alephdata/astro-theme-docs",
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@alephdata/followthemoney": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alephdata/followthemoney/-/followthemoney-3.2.1.tgz",
-      "integrity": "sha512-V78AUXBWwK9vMKzwUaZRE3PUg5O0pHMg2zL5kJtsl6U+7LfXBRd4dJR8GyeRbRddU1It4wjmK/PgR4NHdsGOHg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@alephdata/followthemoney/-/followthemoney-3.5.1.tgz",
+      "integrity": "sha512-V8WO/Hq6AbMJtYfVzNzljWzt3zDXKW3Xm2fMlNhYfw8FrvTRLR3nLfTSMqkeZJEJ5AKjHblef+yBQN/5fnOeCA==",
       "dependencies": {
         "uuid": "~9.0.0"
       },
@@ -7261,9 +7261,9 @@
   },
   "dependencies": {
     "@alephdata/followthemoney": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alephdata/followthemoney/-/followthemoney-3.2.1.tgz",
-      "integrity": "sha512-V78AUXBWwK9vMKzwUaZRE3PUg5O0pHMg2zL5kJtsl6U+7LfXBRd4dJR8GyeRbRddU1It4wjmK/PgR4NHdsGOHg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@alephdata/followthemoney/-/followthemoney-3.5.1.tgz",
+      "integrity": "sha512-V8WO/Hq6AbMJtYfVzNzljWzt3zDXKW3Xm2fMlNhYfw8FrvTRLR3nLfTSMqkeZJEJ5AKjHblef+yBQN/5fnOeCA==",
       "requires": {
         "uuid": "~9.0.0"
       }

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@alephdata/followthemoney": "^3.2.1",
+    "@alephdata/followthemoney": "^3.5.1",
     "@astrojs/markdown-component": "^1.0.2",
     "astro": "^1.4.3",
     "astro-theme-docs": "github:alephdata/astro-theme-docs",

--- a/docs/src/components/explorer/DeprecatedIndicator.astro
+++ b/docs/src/components/explorer/DeprecatedIndicator.astro
@@ -1,0 +1,30 @@
+---
+import { Popover } from 'astro-theme-docs/components';
+const { message } = Astro.props;
+---
+
+<style>
+  .DeprecatedIndicator {
+    display: inline-block;
+    padding-inline: var(--space-xs);
+
+    color: var(--color-fg-negative);
+    background-color: var(--color-bg-negative);
+    border: 1px solid var(--color-border-negative);
+    border-radius: var(--radius-full);
+
+    font-size: calc(0.85 * var(--font-size-sm));
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+
+    cursor: default;
+  }
+</style>
+
+<Popover>
+  <span class="DeprecatedIndicator"> Deprecated</span>
+  <p slot="content">
+    {message}
+  </p>
+</Popover>

--- a/docs/src/components/explorer/SchemaProperties.astro
+++ b/docs/src/components/explorer/SchemaProperties.astro
@@ -3,18 +3,17 @@ import PropertyType from '@components/explorer/PropertyType.astro';
 import SchemaLink from '@components/explorer/SchemaLink.astro';
 import IndexTable from '@components/explorer/IndexTable.astro';
 import PropertyIndicator from '@components/explorer/PropertyIndicator.astro';
+import DeprecatedIndicator from '@components/explorer/DeprecatedIndicator.astro';
 
 const { schema, ...rest } = Astro.props;
 
 const isFeatured = (property) =>
   property.schema.featured.includes(property.name);
-
 const isRequired = (property) =>
   property.schema.required.includes(property.name);
-
 const isHidden = (property) => property.hidden;
-
 const isInherited = (property) => property.schema.name !== schema.name;
+const isDeprecated = (property) => property.deprecated;
 
 const properties = Array.from(schema.getProperties().values())
   .sort((a, b) => a.name.localeCompare(b.name))
@@ -82,6 +81,9 @@ const properties = Array.from(schema.getProperties().values())
             {isFeatured(prop) && <PropertyIndicator type="featured" />}
             {isRequired(prop) && <PropertyIndicator type="required" />}
             {isHidden(prop) && <PropertyIndicator type="hidden" />}
+            {isDeprecated(prop) && (
+              <DeprecatedIndicator message="This property is deprecated and will be removed in a future version of the FollowTheMoney model." />
+            )}
           </td>
 
           <td>{prop.label}</td>

--- a/docs/src/components/explorer/SchemataIndexTable.astro
+++ b/docs/src/components/explorer/SchemataIndexTable.astro
@@ -3,6 +3,7 @@ import { model } from '@util/ftm';
 import IndexTable from '@components/explorer/IndexTable.astro';
 import SchemaLink from '@components/explorer/SchemaLink.astro';
 import BooleanValue from '@components/explorer/BooleanValue.astro';
+import DeprecatedIndicator from '@components/explorer/DeprecatedIndicator.astro';
 
 const schemata = Object.values(model.schemata).sort((a, b) =>
   a.label.localeCompare(b.label)
@@ -23,6 +24,9 @@ const schemata = Object.values(model.schemata).sort((a, b) =>
           <SchemaLink {schema}>
             <code>{schema.name}</code>
           </SchemaLink>
+          {schema.deprecated && (
+            <DeprecatedIndicator message="This schema is deprecated and will be removed in a future version of the FollowTheMoney model." />
+          )}
         </td>
         <td>{schema.label}</td>
         <td>

--- a/docs/src/pages/explorer/schemata/[name].astro
+++ b/docs/src/pages/explorer/schemata/[name].astro
@@ -1,6 +1,6 @@
 ---
 import { model } from '@util/ftm';
-import { Stack, TocNav } from 'astro-theme-docs/components';
+import { Stack, TocNav, Callout } from 'astro-theme-docs/components';
 import ExplorerLayout from '@layouts/ExplorerLayout.astro';
 import SchemaPageHeader from '@components/page/SchemaPageHeader.astro';
 import SchemaInheritance from '@components/explorer/SchemaInheritance.astro';
@@ -29,6 +29,14 @@ const headings = [
 
   <Stack size="xl">
     <SchemaPageHeader schema={schema} />
+    {
+      schema.deprecated && (
+        <Callout theme="danger">
+          This schema is deprecated and will be removed in a future version of
+          the FollowTheMoney model.
+        </Callout>
+      )
+    }
     <SchemaInheritance id="inheritance" schema={schema} />
     <SchemaSemantics id="semantics" schema={schema} />
     <SchemaProperties id="properties" schema={schema} />


### PR DESCRIPTION
This shows small warning indicators in schemata and properties tables (and a popup with an explanation on mouseover), and a warning message below the header on schema pages.

**Schemata table:**

<img width="747" alt="Screen Shot 2023-07-23 at 16 09 07" src="https://github.com/alephdata/followthemoney/assets/1512805/59600e1f-43b7-460a-9ac0-c441155ad61b">

***

**Schema details page:**

<img width="784" alt="Screen Shot 2023-07-23 at 16 08 55" src="https://github.com/alephdata/followthemoney/assets/1512805/512a49fa-c47c-4bcf-aba7-3fa6a4ba4e42">

***

**Properties table:**
(I marked `Thing:address` as deprecated only for demonstration because we currently do not have any deprecated properties.)

<img width="791" alt="Screen Shot 2023-07-23 at 16 08 46" src="https://github.com/alephdata/followthemoney/assets/1512805/1d9959fa-ad43-464e-a522-8b7c51ea6d0c">


