### PR TITLE
Loosen up click requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "types-PyYAML",
         "sqlalchemy2-stubs",
         "banal >= 1.0.6, < 1.1.0",
-        "click >= 8.0, < 8.1.7",
+        "click >= 8.0, < 9.0.0",
         "stringcase >= 1.2.0, < 2.0.0",
         "requests >= 2.21.0, < 3.0.0",
         "python-levenshtein >= 0.12.0, < 1.0.0",


### PR DESCRIPTION
I don't see a reason why we should allow `8.1.6` and not newer version < 9. But perhaps I'm missing something?