### PR TITLE
Mark weak aliases as type 'name' (matchable: false)

### DIFF
--- a/followthemoney/schema/Thing.yaml
+++ b/followthemoney/schema/Thing.yaml
@@ -33,6 +33,7 @@ Thing:
       type: name
     weakAlias:
       label: Weak alias
+      type: name
       matchable: false
     sourceUrl:
       label: Source link


### PR DESCRIPTION
Weak aliases are things like "noms de guerre" (or, handles, like "pudo"). They are names, just shouldn't be included in default matching configurations.