### PR TITLE
add parent entity reference property to RealEstate

### DIFF
--- a/followthemoney/schema/RealEstate.yaml
+++ b/followthemoney/schema/RealEstate.yaml
@@ -48,3 +48,11 @@ RealEstate:
     createDate:
       label: Record date
       type: date
+    parent:
+      label: "Parent unit"
+      description: "If this entity is a subunit, another entity (real estate) is its parent"
+      reverse:
+        label: "Subunits"
+        name: subunits
+      type: entity
+      range: RealEstate


### PR DESCRIPTION
RealEstate objects can often have children, such as a building has individual apartments. It often happens that modeling this relationship is important for investigations. This commit and future pull request addess the ability for a RealEstate entity to have a parent so journalists can see subunits of a building, or which apartments/subunits are associated with a single parent unit.