### PR TITLE
Update links to Aleph documentation

### DIFF
--- a/docs/src/pages/docs/cli.mdx
+++ b/docs/src/pages/docs/cli.mdx
@@ -5,9 +5,9 @@ title: CLI
 
 # Command-Line Functions
 
-Many of the functions of _followthemoney_ can be used interactively or in scripts via the command line. Please first refer to the [Aleph documentation](https://docs.alephdata.org/developers/followthemoney/ftm) for an intro to the `ftm` utility.
+Many of the functions of _followthemoney_ can be used interactively or in scripts via the command line. Please first refer to the [Aleph documentation](https://docs.aleph.occrp.org/developers/followthemoney/ftm) for an intro to the `ftm` utility.
 
-Key to understanding the `ftm` tool is the notion of [streams](/docs#streams): entities can be transferred between programs and processing steps as a series of JSON objects, one per line. This notion is supported by the related [alephclient](https://docs.alephdata.org/developers/alephclient) command, which can serve as a source, and a sink for entity streams, backed by the Aleph API.
+Key to understanding the `ftm` tool is the notion of [streams](/docs#streams): entities can be transferred between programs and processing steps as a series of JSON objects, one per line. This notion is supported by the related [alephclient](https://docs.aleph.occrp.org/developers/alephclient) command, which can serve as a source, and a sink for entity streams, backed by the Aleph API.
 
 ## Examples
 

--- a/docs/src/pages/docs/custom.mdx
+++ b/docs/src/pages/docs/custom.mdx
@@ -31,7 +31,7 @@ For a reference of how schema definitions are designed, use the following resour
 
 Operators can modify the active FtM model by setting the environment variable `FTM_MODEL_PATH` to a directory that contains an alternate set of YAML schema description files. The simplest way to do this would be to download the existing YAML schema set [from FtM source](https://github.com/alephdata/followthemoney/tree/master/followthemoney/schema) and make edits in a new directory.
 
-This raises an difficult question: How mutable is the FtM model in reality? FtM uses specific schemata in its tests, but that wouldn't be a fatal hindrance. However, the [Aleph](https://docs.alephdata.org) and [ingestors](https://github.com/alephdata/ingest-file) have built-in assumptions about a larger subsection of the schema. For example, ingestors require all schemata descendant from `schema:Document` and `schema:Mention`. Aleph assumes that the `schema:LegalEntity`, `schema:Person` and `schema:Document` types exist.
+This raises an difficult question: How mutable is the FtM model in reality? FtM uses specific schemata in its tests, but that wouldn't be a fatal hindrance. However, the [Aleph](https://docs.aleph.occrp.org) and [ingestors](https://github.com/alephdata/ingest-file) have built-in assumptions about a larger subsection of the schema. For example, ingestors require all schemata descendant from `schema:Document` and `schema:Mention`. Aleph assumes that the `schema:LegalEntity`, `schema:Person` and `schema:Document` types exist.
 
 In practice, we would recommend these policies when modifying the FtM model in an Aleph deployment:
 

--- a/docs/src/pages/docs/graphs.mdx
+++ b/docs/src/pages/docs/graphs.mdx
@@ -5,7 +5,7 @@ title: Network Graphs
 
 # Network Graphs
 
-FollowTheMoney includes tooling to export data to a network graph. For details, please refer to the [Aleph documentation](https://docs.alephdata.org/developers/followthemoney/ftm#exporting-data-to-a-network-graph).
+FollowTheMoney includes tooling to export data to a network graph. For details, please refer to the [Aleph documentation](https://docs.aleph.occrp.org/developers/followthemoney/ftm#exporting-data-to-a-network-graph).
 
 ## How entities are translated to a graph
 

--- a/docs/src/pages/docs/mappings.mdx
+++ b/docs/src/pages/docs/mappings.mdx
@@ -7,4 +7,4 @@ title: Mappings
 
 Mappings are a mechanism for generating entities from structured data sources, including tabular data and SQL databases.
 
-Please refer to the [Aleph mappings documentation](https://docs.alephdata.org/developers/mappings) for details.
+Please refer to the [Aleph mappings documentation](https://docs.aleph.occrp.org/developers/mappings) for details.

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -15,5 +15,5 @@ All data stored by the _Aleph search engine_ is expressed as FtM entities. Aleph
 <LinkCard title="Explore the data model" link="/explorer" />
 <LinkCard
   title="Learn more about Aleph"
-  link="https://docs.alephdata.org"
+  link="https://docs.aleph.occrp.org"
 />


### PR DESCRIPTION
It looks like `docs.alephdata.org` is broken for redirects. Using this as an opportunity to update the links to the new docs location. 