### PR TITLE
Improve logging when skipping values or entities in mappings

### DIFF
--- a/followthemoney/mapping/entity.py
+++ b/followthemoney/mapping/entity.py
@@ -129,6 +129,10 @@ class EntityMapping(object):
         # keys.
         proxy.id = self.compute_key(record)
         if proxy.id is None:
+            if self.id_column:
+                log.warn(f"[{self.name}] Skipping entity because no ID could be computed. Make sure that there are no empty values in the \"{self.id_column}\" column.")
+            if self.keys:
+                log.warn(f"[{self.name}] Skipping entity because no ID could be computed. Make sure that there are no empty values in key columns.")
             return None
 
         for prop in self.properties:
@@ -137,6 +141,7 @@ class EntityMapping(object):
                 # the mapping, not in the model. Basically it means: if
                 # this row of source data doesn't have that field, then do
                 # not map it again.
+                log.warn(f"[{self.name}] Skipping entity because required property \"{prop.prop.name}\" is empty.")
                 return None
         return proxy
 

--- a/followthemoney/mapping/property.py
+++ b/followthemoney/mapping/property.py
@@ -112,13 +112,13 @@ class PropertyMapping(object):
 
     def map(
         self, proxy: EntityProxy, record: Record, entities: Dict[str, EntityProxy]
-    ) -> None:
+    ) -> List[str]:
         if self.entity is not None:
             entity = entities.get(self.entity)
             if entity is not None:
                 proxy.unsafe_add(self.prop, entity.id, cleaned=True)
                 inline_names(proxy, entity)
-            return None
+            return []
 
         # clean the values returned by the query, or by using literals, or
         # formats.
@@ -133,5 +133,17 @@ class PropertyMapping(object):
                 splote.extend(value.split(self.split))
             values = splote
 
+        discarded_values: List[str] = []
+
         for value in values:
-            proxy.unsafe_add(self.prop, value, fuzzy=self.fuzzy, format=self.format)
+            added_value = proxy.unsafe_add(
+                prop=self.prop,
+                value=value,
+                fuzzy=self.fuzzy,
+                format=self.format,
+            )
+
+            if value is not None and added_value is None:
+                discarded_values.append(value)
+
+        return discarded_values

--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -206,27 +206,32 @@ class EntityProxy(object):
         cleaned: bool = False,
         fuzzy: bool = False,
         format: Optional[str] = None,
-    ) -> None:
+    ) -> Optional[str]:
         """A version of `add()` to be used only in type-checking code. This accepts
         only a single value, and performs input cleaning on the premise that the
-        value is already valid unicode."""
+        value is already valid unicode. Returns the value that has been added."""
         if not cleaned and value is not None:
             format = format or prop.format
             value = prop.type.clean_text(value, fuzzy=fuzzy, format=format, proxy=self)
-        if value is not None:
-            # Somewhat hacky: limit the maximum size of any particular
-            # field to avoid overloading upstream aleph/elasticsearch.
-            value_size = len(value)
-            if prop.type.max_size is not None:
-                if self._size + value_size > prop.type.max_size:
-                    # msg = "[%s] too large. Rejecting additional values."
-                    # log.warning(msg, prop.name)
-                    return None
-            self._size += value_size
-            self._properties.setdefault(prop.name, list())
-            if value not in self._properties[prop.name]:
-                self._properties[prop.name].append(value)
-        return None
+
+        if value is None:
+            return None
+
+        # Somewhat hacky: limit the maximum size of any particular
+        # field to avoid overloading upstream aleph/elasticsearch.
+        value_size = len(value)
+        if prop.type.max_size is not None:
+            if self._size + value_size > prop.type.max_size:
+                # msg = "[%s] too large. Rejecting additional values."
+                # log.warning(msg, prop.name)
+                return None
+        self._size += value_size
+        self._properties.setdefault(prop.name, list())
+
+        if value not in self._properties[prop.name]:
+            self._properties[prop.name].append(value)
+
+        return value
 
     def set(
         self,

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -83,6 +83,25 @@ class ProxyTestCase(TestCase):
         with raises(InvalidData):
             EntityProxy.from_dict(model, {})
 
+    def test_unsafe_add(self):
+        schema = model.schemata["Person"]
+        prop = schema.properties["phone"]
+
+        proxy = model.make_entity("Person")
+        value = proxy.unsafe_add(prop, "+12025557612")
+        assert value == "+12025557612"
+        assert proxy.get("phone") == ["+12025557612"]
+
+        proxy = model.make_entity("Person")
+        value = proxy.unsafe_add(prop, "+1 (202) 555-7612")
+        assert value == "+12025557612"
+        assert proxy.get("phone") == ["+12025557612"]
+
+        proxy = model.make_entity("Person")
+        value = proxy.unsafe_add(prop, "(202) 555-7612")
+        assert value == None
+        assert proxy.get("phone") == []
+
     def test_pop(self):
         proxy = EntityProxy.from_dict(model, ENTITY)
         get_ids = proxy.get("idNumber")


### PR DESCRIPTION
This is a follow-up to #1404. This PR only includes the changes that improve logging as I agree that completely disabling value cleaning can be dangerous.