### PR TITLE
Always use an array for extends and edge.caption

### DIFF
--- a/followthemoney/schema/Airplane.yaml
+++ b/followthemoney/schema/Airplane.yaml
@@ -1,7 +1,8 @@
 Airplane:
   label: Airplane
   plural: Airplanes
-  extends: Vehicle
+  extends:
+    - Vehicle
   description: >
     An airplane, helicopter or other flying vehicle.
   matchable: true

--- a/followthemoney/schema/Article.yaml
+++ b/followthemoney/schema/Article.yaml
@@ -1,5 +1,6 @@
 Article:
-  extends: Document
+  extends:
+    - Document
   label: Article
   plural: Articles
   description: >

--- a/followthemoney/schema/Assessment.yaml
+++ b/followthemoney/schema/Assessment.yaml
@@ -2,7 +2,8 @@ Assessment:
   # This is overly specific yet not useful. Should we phase it out?
   label: Assessment
   plural: Assessments
-  extends: Thing
+  extends:
+    - Thing
   matchable: false
   featured:
     - name

--- a/followthemoney/schema/Associate.yaml
+++ b/followthemoney/schema/Associate.yaml
@@ -2,7 +2,8 @@ Associate:
   label: "Associate"
   plural: "Associates"
   description: "Non-family association between two people"
-  extends: Interval
+  extends:
+    - Interval
   matchable: false
   featured:
     - person
@@ -16,7 +17,8 @@ Associate:
     label: "associated with"
     target: associate
     directed: false
-    caption: relationship
+    caption:
+      - relationship
   properties:
     person:
       label: "Person"

--- a/followthemoney/schema/Audio.yaml
+++ b/followthemoney/schema/Audio.yaml
@@ -1,5 +1,6 @@
 Audio:
-  extends: Document
+  extends:
+    - Document
   label: Audio
   plural: Audio files
   matchable: false

--- a/followthemoney/schema/BankAccount.yaml
+++ b/followthemoney/schema/BankAccount.yaml
@@ -1,7 +1,8 @@
 BankAccount:
   label: Bank account
   plural: Bank accounts
-  extends: Asset
+  extends:
+    - Asset
   description: >
     An account held at a bank and controlled by an owner. This may also be used 
     to describe more complex arrangements like correspondent bank settlement accounts.

--- a/followthemoney/schema/Contract.yaml
+++ b/followthemoney/schema/Contract.yaml
@@ -4,7 +4,8 @@ Contract:
   description: >
     An contract or contract lot issued by an authority. Multiple lots
     may be awarded to different suppliers (see ContractAward).
-  extends: Asset
+  extends:
+    - Asset
   matchable: false
   featured:
     - title

--- a/followthemoney/schema/ContractAward.yaml
+++ b/followthemoney/schema/ContractAward.yaml
@@ -20,7 +20,8 @@ ContractAward:
     label: "awarded to"
     target: supplier
     directed: true
-    caption: lotNumber
+    caption:
+      - lotNumber
   properties:
     supplier:
       label: "Supplier"

--- a/followthemoney/schema/CourtCase.yaml
+++ b/followthemoney/schema/CourtCase.yaml
@@ -1,7 +1,8 @@
 CourtCase:
   label: Court case
   plural: Court cases
-  extends: Thing
+  extends:
+    - Thing
   matchable: false
   featured:
     - name

--- a/followthemoney/schema/CourtCaseParty.yaml
+++ b/followthemoney/schema/CourtCaseParty.yaml
@@ -1,7 +1,8 @@
 CourtCaseParty:
   label: "Case party"
   plural: "Case parties"
-  extends: Interest
+  extends:
+    - Interest
   matchable: false
   featured:
     - party
@@ -15,7 +16,8 @@ CourtCaseParty:
     label: "involved in"
     target: case
     directed: true
-    caption: role
+    caption:
+      - role
   properties:
     party:
       label: "Party"

--- a/followthemoney/schema/Debt.yaml
+++ b/followthemoney/schema/Debt.yaml
@@ -18,7 +18,8 @@ Debt:
     label: "owes"
     target: creditor
     directed: true
-    caption: amount
+    caption:
+      - amount
   properties:
     debtor:
       label: "Debtor"

--- a/followthemoney/schema/Directorship.yaml
+++ b/followthemoney/schema/Directorship.yaml
@@ -1,7 +1,8 @@
 Directorship:
   label: "Directorship"
   plural: "Directorships"
-  extends: Interest
+  extends:
+    - Interest
   matchable: false
   featured:
     - director
@@ -19,7 +20,8 @@ Directorship:
     label: "directs"
     target: organization
     directed: true
-    caption: role
+    caption:
+      - role
   properties:
     director:
       label: "Director"

--- a/followthemoney/schema/Documentation.yml
+++ b/followthemoney/schema/Documentation.yml
@@ -18,7 +18,8 @@ Documentation:
     label: "documents"
     target: entity
     directed: false
-    caption: role
+    caption:
+      - role
   properties:
     document:
       label: "Document"

--- a/followthemoney/schema/Employment.yaml
+++ b/followthemoney/schema/Employment.yaml
@@ -1,7 +1,8 @@
 Employment:
   label: "Employment"
   plural: "Employments"
-  extends: Interest
+  extends:
+    - Interest
   matchable: false
   featured:
     - employer
@@ -19,7 +20,8 @@ Employment:
     label: "works for"
     target: employer
     directed: true
-    caption: role
+    caption:
+      - role
   properties:
     employer:
       label: "Employer"

--- a/followthemoney/schema/Family.yaml
+++ b/followthemoney/schema/Family.yaml
@@ -2,7 +2,8 @@ Family:
   label: "Family"
   plural: "Family members"
   description: "Family relationship between two people"
-  extends: Interval
+  extends:
+    - Interval
   matchable: false
   featured:
     - person
@@ -16,7 +17,8 @@ Family:
     label: "related to"
     target: relative
     directed: false
-    caption: relationship
+    caption:
+      - relationship
   properties:
     person:
       label: "Person"

--- a/followthemoney/schema/Folder.yaml
+++ b/followthemoney/schema/Folder.yaml
@@ -1,5 +1,6 @@
 Folder:
-  extends: Document
+  extends:
+    - Document
   label: Folder
   plural: Folders
   matchable: false

--- a/followthemoney/schema/HyperText.yaml
+++ b/followthemoney/schema/HyperText.yaml
@@ -1,6 +1,7 @@
 HyperText:
   # HTML document
-  extends: Document
+  extends:
+    - Document
   label: Web page
   plural: Web pages
   matchable: false

--- a/followthemoney/schema/Identification.yaml
+++ b/followthemoney/schema/Identification.yaml
@@ -4,7 +4,8 @@ Identification:
   description: >
     An form of identification associated with its holder and some issuing country. This
     can be used for national ID cards, voter enrollments and similar instruments.
-  extends: Interval
+  extends:
+    - Interval
   matchable: false
   featured:
     - number

--- a/followthemoney/schema/Image.yaml
+++ b/followthemoney/schema/Image.yaml
@@ -1,5 +1,6 @@
 Image:
-  extends: Document
+  extends:
+    - Document
   label: Image
   plural: Images
   description: >

--- a/followthemoney/schema/Interest.yaml
+++ b/followthemoney/schema/Interest.yaml
@@ -1,6 +1,7 @@
 Interest:
   label: "Interest"
-  extends: Interval
+  extends:
+    - Interval
   matchable: false
   abstract: true
   properties:

--- a/followthemoney/schema/LegalEntity.yaml
+++ b/followthemoney/schema/LegalEntity.yaml
@@ -1,5 +1,6 @@
 LegalEntity:
-  extends: Thing
+  extends:
+    - Thing
   label: Legal entity
   plural: Legal entities
   description: >

--- a/followthemoney/schema/Membership.yaml
+++ b/followthemoney/schema/Membership.yaml
@@ -1,7 +1,8 @@
 Membership:
   label: "Membership"
   plural: "Memberships"
-  extends: Interest
+  extends:
+    - Interest
   matchable: false
   featured:
     - member
@@ -19,7 +20,8 @@ Membership:
     label: "belongs to"
     target: organization
     directed: true
-    caption: role
+    caption:
+      - role
   properties:
     member:
       label: "Member"

--- a/followthemoney/schema/Occupancy.yaml
+++ b/followthemoney/schema/Occupancy.yaml
@@ -1,7 +1,8 @@
 Occupancy:
   label: "Occupancy"
   plural: "Occupancies"
-  extends: Interval
+  extends:
+    - Interval
   matchable: false
   description: >
     The occupation of a position by a person for a specific period of time.

--- a/followthemoney/schema/Organization.yaml
+++ b/followthemoney/schema/Organization.yaml
@@ -1,5 +1,6 @@
 Organization:
-  extends: LegalEntity
+  extends:
+    - LegalEntity
   label: Organization
   plural: Organizations
   description: >

--- a/followthemoney/schema/Ownership.yaml
+++ b/followthemoney/schema/Ownership.yaml
@@ -1,7 +1,8 @@
 Ownership:
   label: "Ownership"
   plural: "Ownerships"
-  extends: Interest
+  extends:
+    - Interest
   matchable: false
   featured:
     - owner
@@ -17,7 +18,8 @@ Ownership:
     label: "owns"
     target: asset
     directed: true
-    caption: percentage
+    caption:
+      - percentage
   properties:
     owner:
       label: "Owner"

--- a/followthemoney/schema/Package.yaml
+++ b/followthemoney/schema/Package.yaml
@@ -1,5 +1,6 @@
 Package:
-  extends: Folder
+  extends:
+    - Folder
   label: Package
   plural: Packages
   description: >

--- a/followthemoney/schema/Pages.yaml
+++ b/followthemoney/schema/Pages.yaml
@@ -1,5 +1,6 @@
 Pages:
-  extends: Document
+  extends:
+    - Document
   label: Document
   description: >
     A multi-page document, such as a PDF or Word file or slide-show presentation.

--- a/followthemoney/schema/Passport.yaml
+++ b/followthemoney/schema/Passport.yaml
@@ -3,7 +3,8 @@ Passport:
   plural: "Passports"
   description: >
     An passport held by a person.
-  extends: Identification
+  extends:
+    - Identification
   matchable: false
   featured:
     - passportNumber

--- a/followthemoney/schema/Person.yaml
+++ b/followthemoney/schema/Person.yaml
@@ -1,5 +1,6 @@
 Person:
-  extends: LegalEntity
+  extends:
+    - LegalEntity
   label: Person
   plural: People
   description: >

--- a/followthemoney/schema/PlainText.yaml
+++ b/followthemoney/schema/PlainText.yaml
@@ -1,5 +1,6 @@
 PlainText:
-  extends: Document
+  extends:
+    - Document
   label: Text file
   plural: Text files
   description: >

--- a/followthemoney/schema/Position.yaml
+++ b/followthemoney/schema/Position.yaml
@@ -1,7 +1,8 @@
 Position:
   label: "Position"
   plural: "Positions"
-  extends: Thing
+  extends:
+    - Thing
   matchable: true
   # cf. https://www.popoloproject.com/specs/post.html
   description: >

--- a/followthemoney/schema/Post.yaml
+++ b/followthemoney/schema/Post.yaml
@@ -1,7 +1,8 @@
 Post:
   label: "Post"
   plural: "Posts"
-  extends: Interest
+  extends:
+    - Interest
   matchable: false
   deprecated: true
   # cf. https://www.popoloproject.com/specs/post.html

--- a/followthemoney/schema/ProjectParticipant.yaml
+++ b/followthemoney/schema/ProjectParticipant.yaml
@@ -1,7 +1,8 @@
 ProjectParticipant:
   label: Project participant
   plural: Project participants
-  extends: Interest
+  extends:
+    - Interest
   description: >
     An activity carried out by a group of participants.
   matchable: false
@@ -16,7 +17,8 @@ ProjectParticipant:
     label: "participates in"
     target: project
     directed: true
-    caption: role
+    caption:
+      - role
   properties:
     project:
       label: "Project"

--- a/followthemoney/schema/PublicBody.yaml
+++ b/followthemoney/schema/PublicBody.yaml
@@ -3,7 +3,8 @@ PublicBody:
   plural: Public bodies
   description: >
     A public body, such as a ministry, department or state company.
-  extends: Organization
+  extends:
+    - Organization
   matchable: true
   featured:
     - name

--- a/followthemoney/schema/RealEstate.yaml
+++ b/followthemoney/schema/RealEstate.yaml
@@ -1,5 +1,6 @@
 RealEstate:
-  extends: Asset
+  extends:
+    - Asset
   label: Real estate
   plural: Real estates
   description: "A piece of land or property."

--- a/followthemoney/schema/Representation.yaml
+++ b/followthemoney/schema/Representation.yaml
@@ -2,7 +2,8 @@ Representation:
   label: "Representation"
   plural: "Representations"
   description: "A mediatory, intermediary, middleman, or broker acting on behalf of a legal entity."
-  extends: Interest
+  extends:
+    - Interest
   matchable: false
   featured:
     - agent
@@ -16,7 +17,8 @@ Representation:
     label: "represents"
     target: client
     directed: true
-    caption: role
+    caption:
+      - role
   properties:
     agent: # aka representative / incorporation agent
       label: "Agent"

--- a/followthemoney/schema/Sanction.yaml
+++ b/followthemoney/schema/Sanction.yaml
@@ -2,7 +2,8 @@ Sanction:
   label: Sanction
   plural: Sanctions
   description: "A sanction designation"
-  extends: Interval
+  extends:
+    - Interval
   matchable: false
   featured:
     - entity

--- a/followthemoney/schema/Security.yaml
+++ b/followthemoney/schema/Security.yaml
@@ -1,5 +1,6 @@
 Security:
-  extends: Asset
+  extends:
+    - Asset
   label: Security
   plural: Securities
   description: "A tradeable financial asset."

--- a/followthemoney/schema/Succession.yaml
+++ b/followthemoney/schema/Succession.yaml
@@ -2,7 +2,8 @@ Succession:
   label: "Succession"
   plural: "Successions"
   description: "Two entities that legally succeed each other."
-  extends: Interest
+  extends:
+    - Interest
   matchable: false
   featured:
     - predecessor
@@ -16,7 +17,8 @@ Succession:
     label: "preceeds"
     target: successor
     directed: true
-    caption: date
+    caption:
+      - date
   properties:
     predecessor:
       label: "Predecessor"

--- a/followthemoney/schema/Table.yaml
+++ b/followthemoney/schema/Table.yaml
@@ -1,5 +1,6 @@
 Table:
-  extends: Document
+  extends:
+    - Document
   label: Table
   plural: Tables
   description: >

--- a/followthemoney/schema/TaxRoll.yaml
+++ b/followthemoney/schema/TaxRoll.yaml
@@ -2,7 +2,8 @@ TaxRoll:
   label: "Tax roll"
   plural: "Tax rolls"
   description: "A tax declaration of an individual"
-  extends: Interval
+  extends:
+    - Interval
   icon: fa-bank
   matchable: false
   featured:

--- a/followthemoney/schema/UnknownLink.yaml
+++ b/followthemoney/schema/UnknownLink.yaml
@@ -2,7 +2,8 @@
 UnknownLink:
   label: "Other link"
   plural: "Other links"
-  extends: Interest
+  extends:
+    - Interest
   matchable: false
   featured:
     - subject
@@ -16,7 +17,8 @@ UnknownLink:
     label: "linked to"
     target: object
     directed: false
-    caption: role
+    caption:
+      - role
   properties:
     subject:
       label: "Subject"

--- a/followthemoney/schema/Vehicle.yaml
+++ b/followthemoney/schema/Vehicle.yaml
@@ -1,7 +1,8 @@
 Vehicle:
   label: Vehicle
   plural: Vehicles
-  extends: Asset
+  extends:
+    - Asset
   matchable: false
   featured:
     - type

--- a/followthemoney/schema/Vessel.yaml
+++ b/followthemoney/schema/Vessel.yaml
@@ -3,7 +3,8 @@ Vessel:
   plural: Vessels
   description: >
     A boat or ship. Typically flying some sort of national flag.
-  extends: Vehicle
+  extends:
+    - Vehicle
   matchable: true
   featured:
     - name

--- a/followthemoney/schema/Video.yaml
+++ b/followthemoney/schema/Video.yaml
@@ -1,5 +1,6 @@
 Video:
-  extends: Document
+  extends:
+    - Document
   label: Video
   plural: Videos
   matchable: false

--- a/followthemoney/schema/Workbook.yaml
+++ b/followthemoney/schema/Workbook.yaml
@@ -1,5 +1,6 @@
 Workbook:
-  extends: Folder
+  extends:
+    - Folder
   label: Workbook
   plural: Workbooks
   description: >


### PR DESCRIPTION
`extends and `edge.caption` was sometimes (not always) a string value when there's just one entry, instead of an array wiht one entry.

This is kind of annoying to parse and deal with; e.g. in Go I need to have a custom type with UnmarshalYAML(). Not hugely complex, but 17 lines of code I could do without. And even in more dynmic languages like Python you'll need an "if" to deal with it.

So just change it to consistently be an array.