### PR TITLE
Bump identifier length to handle XMR addresses

### DIFF
--- a/followthemoney/types/identifier.py
+++ b/followthemoney/types/identifier.py
@@ -26,7 +26,7 @@ class IdentifierType(PropertyType):
     plural = _("Identifiers")
     matchable = True
     pivot = True
-    max_length = 64
+    max_length = 128
 
     def clean_text(
         self,


### PR DESCRIPTION
We'd like to be able to represent the XMR addresses at https://www.treasury.gov/ofac/downloads/sanctions/1.0/sdn_advanced.xml as CryptoWallet:publicKey

They are 96 chars long.