### PR TITLE
fix: add name to Contract

### DIFF
--- a/followthemoney/schema/Contract.yaml
+++ b/followthemoney/schema/Contract.yaml
@@ -25,6 +25,9 @@ Contract:
     title:
       label: "Title"
       type: string
+    name:
+      label: "Name"
+      type: name
     authority:
       label: "Contract authority"
       plural: "Contract authorities"


### PR DESCRIPTION
Hello,

We are using the aleph FtM models to [generate Java classes](https://github.com/ICIJ/ftm.java) that we are going to integrate into datashare. When the code is generated, there are compilation issues.

I can't see any ways of finding `name` for a `License` object. How could I find the description of this property?

I noticed also that `CallForTenders.title` has no title is it on purpose?

Finally some fields are required but not listed in properties, is it a wanted behaviour?

Thank you for your answers.