### PR TITLE
Post release announcements to Discourse

### DIFF
--- a/.github/workflows/discourse.yml
+++ b/.github/workflows/discourse.yml
@@ -1,0 +1,18 @@
+name: Post release topic on Discourse
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: roots/discourse-topic-github-release-action@c30dc233349b7c6f24f52fb1c659cc64f13b5474
+      with:
+        discourse-api-key: ${{ secrets.DISCOURSE_RELEASES_API_KEY }}
+        discourse-base-url: https://aleph.discourse.group/
+        discourse-category: 5
+        discourse-tags: |
+          release
+          ftm


### PR DESCRIPTION
This is in line with what we do for [Aleph](https://aleph.discourse.group/t/aleph-4-0-1-released/124) and [ingest-file](https://aleph.discourse.group/t/ingest-file-4-0-1-released/125). FYI, I hope it's ok with you, @pudo ? 

P.S: to clarify, this is triggered only when a Github Release is created.