### PR TITLE
fix: path to TypeScript declarations

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "main": "dist/followthemoney.umd.js",
   "module": "dist/followthemoney.es5.js",
-  "typings": "dist/types/followthemoney.d.ts",
+  "typings": "dist/followthemoney.d.ts",
   "sideEffects": false,
   "files": [
     "dist"


### PR DESCRIPTION
In ce9fb7b1438c59badd08bf0493bddafa4aa40d35, `declarationDir` was updated from `./dist/types` to `./dist`. However, `typings` in `package.json` weren't updated.

This PR fixes this issue.
