### PR TITLE
Fix property tables

### DIFF
--- a/docs/src/components/explorer/SchemaProperties.astro
+++ b/docs/src/components/explorer/SchemaProperties.astro
@@ -41,8 +41,8 @@ const properties = Array.from(schema.getProperties().values())
     opacity: 66%;
   }
 
-  [data-show-inherited='false'] [data-is-inherited]:not(:has(:target)),
-  [data-show-stubs='false'] [data-is-stub]:not(:has(:target)) {
+  [data-show-inherited='false'] [data-is-inherited='true']:not(:has(:target)),
+  [data-show-stubs='false'] [data-is-stub='true']:not(:has(:target)) {
     display: none;
   }
 


### PR DESCRIPTION
I broke the properties listings the model explorer in #1630. The current Astro version renders `data-key={false}` as `data-key="false"` whereas the previous version would simply omit the entire attribute in that case.