### PR TITLE
Add `proof` to Interval

### DIFF
--- a/followthemoney/schema/Interval.yaml
+++ b/followthemoney/schema/Interval.yaml
@@ -72,3 +72,10 @@ Interval:
       label: "Retrieved on"
       type: date
       matchable: false
+    proof:
+      label: Source document
+      reverse:
+        name: proven
+        label: "Derived entities"
+      type: entity
+      range: Document


### PR DESCRIPTION
Limiting `proof` to Thing is problematic:
- It is impossible to express when an Interval is proved by a Document. 
- There's nothing 'Thing'y about a `proof` at all. It's an arbitrary limitation. In the domain of FollowTheMoney investigations an `Ownership` or `Payment` is more likely to be Documented than a `Company` or `RealEstate`.
- As more automatic processes generate entities from unstructured data (ingest-file style), we need to express where these entities came from.

I address this by adding the same property to Interval.

Note: I haven't touched Documentation. The same logic applies but the implementation is more challenging. In Documentation, the range of `entity` should be Thing|Interval, not Thing. That doesn't seem to be possible, as it doesn't seem that Thing and Entity share a common ancestor.
