### PR TITLE
Whitelist Bengali language

### DIFF
--- a/followthemoney/types/language.py
+++ b/followthemoney/types/language.py
@@ -89,6 +89,7 @@ class LanguageType(EnumType):
         "mya",
         "khm",
         "cnr",
+        "ben",
     ]
     LANGUAGES = get_env_list("FTM_LANGUAGES", LANGUAGES)
     LANGUAGES = [lang.lower().strip() for lang in LANGUAGES]

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -7936,6 +7936,7 @@
         "ara": "Arabic",
         "aze": "Azerbaijani",
         "bel": "Belarusian",
+        "ben": "Bangla",
         "bos": "Bosnian",
         "bul": "Bulgarian",
         "cat": "Catalan",

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -7936,6 +7936,7 @@
         "ara": "Arabic",
         "aze": "Azerbaijani",
         "bel": "Belarusian",
+        "ben": "Bangla",
         "bos": "Bosnian",
         "bul": "Bulgarian",
         "cat": "Catalan",


### PR DESCRIPTION
This adds https://iso639-3.sil.org/code/ben to the list of supported languages.