### PR TITLE
Adopt PyICU as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,12 @@ dependencies = [
     "prefixdate >= 0.4.0, < 1.0.0",
     "fingerprints >= 1.0.1, < 2.0.0",
     "phonenumbers >= 8.12.22, < 10.0.0",
-    "python-stdnum >= 1.16, < 2.0.0",
     "pytz >= 2021.1",
     "rdflib >= 6.2.0, < 7.2.0",
     "networkx >= 2.5, < 3.5",
     "openpyxl >= 3.0.5, < 4.0.0",
     "orjson >= 3.7, < 4.0",
+    "pyicu >= 2.15, < 3.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
I'd like to propose that we make PyICU a dependency of followthemoney. The packaging on the library has improved lots since this project started, and making PyICU optional is a weird source of new developer heisenbugs. 