### PR TITLE
Remove dependency on `fingerprints`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           sudo apt-get update -y -qq
           sudo apt-get install -y -qq libicu-dev
-          python -m pip install --upgrade pip wheel pyicu
+          python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Run checks for default model
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install followthemoney Python package
         run: make dev

--- a/followthemoney/compare.py
+++ b/followthemoney/compare.py
@@ -1,10 +1,13 @@
 import math
-import itertools
+from itertools import islice, product
 from typing import Dict, Generator, Iterable, List, Optional
-import fingerprints
 from normality import normalize
+from rigour.names import tokenize_name
+from rigour.names.person import remove_person_prefixes
+from rigour.names.org_types import replace_org_types_compare
 from followthemoney.exc import InvalidData
 from followthemoney.model import Model
+from followthemoney.schema import Schema
 from followthemoney.types import registry
 from followthemoney.proxy import EntityProxy
 from followthemoney.types.common import PropertyType
@@ -30,7 +33,7 @@ COMPARE_WEIGHTS: Weights = {
 def compare_scores(model: Model, left: EntityProxy, right: EntityProxy) -> Scores:
     """Compare two entities and return a match score for each property."""
     try:
-        model.common_schema(left.schema, right.schema)
+        common = model.common_schema(left.schema, right.schema)
     except InvalidData:
         return {}
     scores: Scores = {}
@@ -42,7 +45,7 @@ def compare_scores(model: Model, left: EntityProxy, right: EntityProxy) -> Score
         group = registry.groups[group_name]
         try:
             if group == registry.name:
-                score = compare_names(left, right)
+                score = compare_names(common, left, right)
             elif group == registry.country:
                 score = compare_countries(left, right)
             else:
@@ -81,18 +84,29 @@ def compare(
     return _compare(scores, weights)
 
 
-def _normalize_names(names: Iterable[str]) -> Generator[str, None, None]:
+def _normalize_names(
+    schema: Schema, names: Iterable[str]
+) -> Generator[str, None, None]:
     """Generate a sequence of comparable names for an entity. This also
-    generates a `fingerprint`, i.e. a version of the name where all tokens
+    generates a fingerprint, i.e. a version of the name where all tokens
     are sorted alphabetically, and some parts, such as company suffixes,
     have been removed."""
     seen = set()
+    can_person = schema.is_a("LegalEntity") and not schema.is_a("Organization")
+    can_org = schema.is_a("LegalEntity") and not schema.is_a("Person")
     for name in names:
         plain = normalize(name, ascii=True)
         if plain is not None and plain not in seen:
             seen.add(plain)
             yield plain
-        fp = fingerprints.generate(name)
+        if not can_org and not can_person:
+            continue
+        if can_person:
+            name = remove_person_prefixes(name)
+        if can_org:
+            name = replace_org_types_compare(name)
+        tokens = tokenize_name(name.lower())
+        fp = " ".join(sorted(tokens))
         if fp is not None and len(fp) > 6 and fp not in seen:
             seen.add(fp)
             yield fp
@@ -109,16 +123,16 @@ def compare_group(
 
 
 def compare_names(
-    left: EntityProxy, right: EntityProxy, max_names: int = 200
+    common: Schema, left: EntityProxy, right: EntityProxy, max_names: int = 200
 ) -> Optional[float]:
     result = 0.0
-    left_list = list(itertools.islice(_normalize_names(left.names), max_names))
-    right_list = list(itertools.islice(_normalize_names(right.names), max_names))
+    left_list = list(islice(_normalize_names(common, left.names), max_names))
+    right_list = list(islice(_normalize_names(common, right.names), max_names))
     if not left_list and not right_list:
         raise ValueError("At least one proxy must have name properties")
     elif not left_list or not right_list:
         return None
-    for (left_val, right_val) in itertools.product(left_list, right_list):
+    for left_val, right_val in product(left_list, right_list):
         similarity = registry.name.compare(left_val, right_val)
         result = max(result, similarity)
         if result == 1.0:

--- a/followthemoney/types/name.py
+++ b/followthemoney/types/name.py
@@ -2,9 +2,8 @@ from typing import TYPE_CHECKING, Optional, Sequence
 from normality import slugify
 from normality.cleaning import collapse_spaces, strip_quotes
 from rigour.env import MAX_NAME_LENGTH
-from rigour.names import pick_name
+from rigour.names import pick_name, tokenize_name
 from rigour.text.distance import levenshtein_similarity
-from fingerprints.cleanup import clean_name_light
 
 from followthemoney.types.common import PropertyType
 from followthemoney.util import dampen
@@ -51,9 +50,9 @@ class NameType(PropertyType):
 
     def compare(self, left: str, right: str) -> float:
         """Compare two names for similarity."""
-        left_clean = clean_name_light(left)
-        right_clean = clean_name_light(right)
-        if left_clean is None or right_clean is None:
+        left_clean = " ".join(tokenize_name(left.lower()))
+        right_clean = " ".join(tokenize_name(right.lower()))
+        if not len(left_clean) or not len(right_clean):
             return 0.0
         return levenshtein_similarity(
             left_clean,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "types-PyYAML",
     "sqlalchemy2-stubs",
     "banal >= 1.0.6, < 1.1.0",
-    "rigour >= 0.10.0, < 1.0.0",
+    "rigour >= 0.10.1, < 1.0.0",
     "click >= 8.0, < 9.0.0",
     "requests >= 2.21.0, < 3.0.0",
     "normality >= 2.4.0, < 3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "sqlalchemy >= 1.4.49, < 3.0.0",
     "countrynames >= 1.13.0, < 2.0.0",
     "prefixdate >= 0.4.0, < 1.0.0",
-    "fingerprints >= 1.0.1, < 2.0.0",
     "phonenumbers >= 8.12.22, < 10.0.0",
     "python-stdnum >= 1.16, < 2.0.0",
     "pytz >= 2021.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "types-PyYAML",
     "sqlalchemy2-stubs",
     "banal >= 1.0.6, < 1.1.0",
-    "rigour >= 0.9.3, < 1.0.0",
+    "rigour >= 0.10.0, < 1.0.0",
     "click >= 8.0, < 9.0.0",
     "requests >= 2.21.0, < 3.0.0",
     "normality >= 2.4.0, < 3.0.0",

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,9 +1,9 @@
+import pytest
 from copy import deepcopy
-from unittest import TestCase
 
 from followthemoney import model
 from followthemoney.compare import compare, compare_names
-import pytest
+
 
 ENTITY = {
     "id": "test",

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from followthemoney import model
 from followthemoney.compare import compare, compare_names
+import pytest
 
 ENTITY = {
     "id": "test",
@@ -16,58 +17,60 @@ ENTITY = {
 }
 
 
-class CompareTestCase(TestCase):
-    def test_compare_names(self):
-        left = {"schema": "Person", "properties": {"name": ["mr frank banana"]}}  # noqa
-        left = model.get_proxy(left)
-        right = {
+def test_compare_names():
+    left = {"schema": "Person", "properties": {"name": ["mr frank banana"]}}
+    left = model.get_proxy(left)
+    right = {
+        "schema": "Person",
+        "properties": {"name": ["mr frank bananoid"]},
+    }
+    right = model.get_proxy(right)
+    same_score = compare_names(left.schema, left, left)
+    assert same_score > 0.5, same_score
+    lr_score = compare_names(left.schema, left, right)
+    assert lr_score > 0.1, lr_score
+    assert lr_score < same_score, (lr_score, same_score)
+
+
+def test_compare_countries():
+    left = model.get_proxy(
+        {
             "schema": "Person",
-            "properties": {"name": ["mr frank bananoid"]},
-        }  # noqa
-        right = model.get_proxy(right)
-        same_score = compare_names(left.schema, left, left)
-        assert same_score > 0.5, same_score
-        lr_score = compare_names(left.schema, left, right)
-        assert lr_score > 0.1, lr_score
-        assert lr_score < same_score, (lr_score, same_score)
+            "properties": {"name": ["Frank Banana"], "nationality": ["ie"]},
+        }
+    )
+    no_country = model.get_proxy(
+        {"schema": "Person", "properties": {"name": ["Frank Banana"]}}
+    )
+    baseline = compare(model, left, no_country)
+    assert compare(model, left, left) > baseline
 
-    def test_compare_countries(self):
-        left = model.get_proxy(
-            {
-                "schema": "Person",
-                "properties": {"name": ["Frank Banana"], "nationality": ["ie"]},
-            }
-        )
-        no_country = model.get_proxy(
-            {"schema": "Person", "properties": {"name": ["Frank Banana"]}}
-        )
-        baseline = compare(model, left, no_country)
-        self.assertGreater(compare(model, left, left), baseline)
 
-    def test_compare_basic(self):
-        entity = model.get_proxy(ENTITY)
-        best_score = compare(model, entity, entity)
-        assert best_score > 0.5, best_score
-        comp = model.get_proxy({"schema": "RealEstate"})
-        self.assertAlmostEqual(compare(model, entity, comp), 0)
-        self.assertAlmostEqual(compare(model, comp, comp), 0)
+def test_compare_basic():
+    entity = model.get_proxy(ENTITY)
+    best_score = compare(model, entity, entity)
+    assert best_score > 0.5, best_score
+    comp = model.get_proxy({"schema": "RealEstate"})
+    assert compare(model, entity, comp) == pytest.approx(0)
+    assert compare(model, comp, comp) == pytest.approx(0)
 
-        comp = model.get_proxy({"schema": "Person"})
-        self.assertAlmostEqual(compare(model, entity, comp), 0)
+    comp = model.get_proxy({"schema": "Person"})
+    assert compare(model, entity, comp) == pytest.approx(0)
 
-        comp = model.get_proxy({"schema": "LegalEntity"})
-        self.assertAlmostEqual(compare(model, entity, comp), 0)
+    comp = model.get_proxy({"schema": "LegalEntity"})
+    assert compare(model, entity, comp) == pytest.approx(0)
 
-    def test_compare_quality(self):
-        entity = model.get_proxy(ENTITY)
-        best_score = compare(model, entity, entity)
-        reduced = deepcopy(ENTITY)
-        reduced["properties"].pop("birthDate")
-        reduced["properties"].pop("idNumber")
-        reduced_proxy = model.get_proxy(reduced)
-        self.assertLess(compare(model, entity, reduced_proxy), best_score)
 
-        reduced = deepcopy(ENTITY)
-        reduced["properties"]["name"] = ["Frank Banana"]
-        reduced_proxy = model.get_proxy(reduced)
-        self.assertLess(compare(model, entity, reduced_proxy), best_score)
+def test_compare_quality():
+    entity = model.get_proxy(ENTITY)
+    best_score = compare(model, entity, entity)
+    reduced = deepcopy(ENTITY)
+    reduced["properties"].pop("birthDate")
+    reduced["properties"].pop("idNumber")
+    reduced_proxy = model.get_proxy(reduced)
+    assert compare(model, entity, reduced_proxy) < best_score
+
+    reduced = deepcopy(ENTITY)
+    reduced["properties"]["name"] = ["Frank Banana"]
+    reduced_proxy = model.get_proxy(reduced)
+    assert compare(model, entity, reduced_proxy) < best_score

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -25,9 +25,9 @@ class CompareTestCase(TestCase):
             "properties": {"name": ["mr frank bananoid"]},
         }  # noqa
         right = model.get_proxy(right)
-        same_score = compare_names(left, left)
+        same_score = compare_names(left.schema, left, left)
         assert same_score > 0.5, same_score
-        lr_score = compare_names(left, right)
+        lr_score = compare_names(left.schema, left, right)
         assert lr_score > 0.1, lr_score
         assert lr_score < same_score, (lr_score, same_score)
 


### PR DESCRIPTION
This is to prepare for the next `rigour` release, which includes all of fingerprint's name normalization functionality.