### PR TITLE
Move RDF exporter to module

### DIFF
--- a/followthemoney/cli/exports.py
+++ b/followthemoney/cli/exports.py
@@ -6,8 +6,6 @@ from contextlib import contextmanager
 from followthemoney.cli.cli import cli
 from followthemoney.cli.util import InPath, OutPath, export_stream
 from followthemoney.export.csv import CSVExporter
-from followthemoney.export.rdf import RDFExporter
-from followthemoney.export.excel import ExcelExporter
 from followthemoney.export.graph import edge_types, DEFAULT_EDGE_TYPES
 from followthemoney.export.graph import NXGraphExporter
 from followthemoney.export.neo4j import Neo4JCSVExporter
@@ -46,6 +44,9 @@ def export_csv(infile: Path, outdir: Path) -> None:
     required=True,
 )
 def export_excel(infile: Path, outfile: Path) -> None:
+    # lazt load openpyxl
+    from followthemoney.export.excel import ExcelExporter
+
     exporter = ExcelExporter(outfile)
     export_stream(exporter, infile)
 
@@ -60,6 +61,9 @@ def export_excel(infile: Path, outfile: Path) -> None:
     help="Generate full predicates",
 )
 def export_rdf(infile: Path, outfile: Path, qualified: bool = True) -> None:
+    # Lazy load rdflib
+    from followthemoney.export.rdf import RDFExporter
+
     with text_out(outfile) as fh:
         exporter = RDFExporter(fh, qualified=qualified)
         export_stream(exporter, infile)

--- a/followthemoney/export/rdf.py
+++ b/followthemoney/export/rdf.py
@@ -1,23 +1,73 @@
 import logging
-from rdflib import Graph
-from typing import List, Optional, TextIO
+from prefixdate import Precision
+from rdflib import Graph, Namespace
+from rdflib.term import Identifier, URIRef, Literal
+from rdflib import RDF, SKOS, XSD
+from typing import Generator, List, Optional, TextIO, Tuple
 
 from followthemoney.export.common import Exporter
+from followthemoney.types import registry
 from followthemoney.proxy import E
 
 log = logging.getLogger(__name__)
+Triple = Tuple[Identifier, Identifier, Identifier]
+NS = Namespace("https://schema.followthemoney.tech/#")
 
 
 class RDFExporter(Exporter):
+    """Export the entity as RDF N-Triples."""
+
+    TYPE_PREFIXES = {
+        registry.checksum: "hash:",
+        registry.country: "http://id.loc.gov/vocabulary/countries/",
+        registry.email: "mailto:",
+        registry.entity: "e:",
+        registry.gender: "gender:",
+        registry.iban: "iban:",
+        registry.ip: "ip:",
+        registry.language: "http://lexvo.org/id/iso639-3/",
+        registry.mimetype: "urn:mimetype:",
+        registry.phone: "tel:",
+        registry.topic: "ftm:topic:",
+    }
+
     def __init__(self, fh: TextIO, qualified: bool = True) -> None:
         super(RDFExporter, self).__init__()
         self.fh = fh
         self.qualified = qualified
 
+    def entity_triples(self, proxy: E) -> Generator[Triple, None, None]:
+        if proxy.id is None or proxy.schema is None:
+            return
+        entity_prefix = self.TYPE_PREFIXES[registry.entity]
+        uri = URIRef(f"{entity_prefix}{proxy.id}")
+        yield (uri, RDF.type, NS[proxy.schema.name])
+        if self.qualified:
+            caption = proxy.caption
+            if caption != proxy.schema.label:
+                yield (uri, SKOS.prefLabel, Literal(caption))
+        for prop, value in proxy.itervalues():
+            if prop.type in self.TYPE_PREFIXES:
+                prefix = self.TYPE_PREFIXES[prop.type]
+                obj: Identifier = URIRef(f"{prefix}{value}")
+            elif prop.type == registry.date:
+                if len(value) < Precision.HOUR.value:
+                    obj = Literal(value, datatype=XSD.date)
+                else:
+                    obj = Literal(value, datatype=XSD.dateTime)
+            elif prop.type == registry.url:
+                obj = URIRef(value)
+            else:
+                obj = Literal(value)
+            if self.qualified:
+                yield (uri, NS[prop.qname], obj)
+            else:
+                yield (uri, URIRef(prop.name), obj)
+
     def write(self, proxy: E, extra: Optional[List[str]] = None) -> None:
         graph = Graph()
 
-        for triple in proxy.triples(qualified=self.qualified):
+        for triple in self.entity_triples(proxy):
             graph.add(triple)
         try:
             nt = graph.serialize(format="nt11").strip()

--- a/followthemoney/ontology.py
+++ b/followthemoney/ontology.py
@@ -1,14 +1,15 @@
 import sys
 from datetime import datetime
-from rdflib import Graph, URIRef, Literal
+from rdflib import Graph, URIRef, Literal, Namespace
 from rdflib.namespace import OWL, DCTERMS, RDF, RDFS, XSD
 
 from followthemoney import model
 from followthemoney.property import Property
 from followthemoney.schema import Schema
 from followthemoney.types import registry
-from followthemoney.rdf import NS
 from followthemoney.util import PathLike
+
+NS = Namespace("https://schema.followthemoney.tech/#")
 
 
 class Ontology(object):

--- a/followthemoney/property.py
+++ b/followthemoney/property.py
@@ -1,9 +1,8 @@
 from banal import is_mapping, as_bool
-from typing import TYPE_CHECKING, cast, Any, List, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, List, Optional, TypedDict
 
 from followthemoney.exc import InvalidModel
 from followthemoney.types import registry
-from followthemoney.rdf import NS, URIRef
 from followthemoney.util import gettext, get_entity_id
 
 if TYPE_CHECKING:
@@ -136,9 +135,6 @@ class Property:
         #: views.
         self._reverse = data.get("reverse")
         self.reverse: Optional["Property"] = None
-
-        #: RDF term for this property (i.e. the predicate URI).
-        self.uri = URIRef(cast(str, data.get("rdf", NS[self.qname])))
 
     def generate(self, model: "Model") -> None:
         """Setup method used when loading the model in order to build out the reverse

--- a/followthemoney/property.py
+++ b/followthemoney/property.py
@@ -25,7 +25,6 @@ class PropertyDict(TypedDict, total=False):
     deprecated: Optional[bool]
     maxLength: Optional[int]
     # stub: Optional[bool]
-    rdf: Optional[str]
     range: Optional[str]
     format: Optional[str]
 
@@ -65,7 +64,6 @@ class Property:
         "stub",
         "_reverse",
         "reverse",
-        "uri",
     )
 
     #: Invalid property names.

--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -21,7 +21,6 @@ from followthemoney.exc import InvalidData
 from followthemoney.types import registry
 from followthemoney.types.common import PropertyType
 from followthemoney.property import Property
-from followthemoney.rdf import SKOS, RDF, Literal, URIRef, Identifier
 from followthemoney.util import sanitize_text, gettext
 from followthemoney.util import merge_context, value_list, make_entity_id
 
@@ -30,7 +29,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 P = Union[Property, str]
-Triple = Tuple[Identifier, Identifier, Identifier]
 E = TypeVar("E", bound="EntityProxy")
 
 
@@ -376,26 +374,6 @@ class EntityProxy(object):
             if len(values):
                 data[group] = values
         return data
-
-    def triples(self, qualified: bool = True) -> Generator[Triple, None, None]:
-        """Serialise the entity into a set of RDF triple statements. The
-        statements include the property values, an ``RDF#type`` definition
-        that refers to the entity schema, and a ``SKOS#prefLabel`` with the
-        entity caption."""
-        if self.id is None or self.schema is None:
-            return
-        uri = registry.entity.rdf(self.id)
-        yield (uri, RDF.type, self.schema.uri)
-        if qualified:
-            caption = self.caption
-            if caption != self.schema.label:
-                yield (uri, SKOS.prefLabel, Literal(caption))
-        for prop, value in self.itervalues():
-            value = prop.type.rdf(value)
-            if qualified:
-                yield (uri, prop.uri, value)
-            else:
-                yield (uri, URIRef(prop.name), value)
 
     @property
     def caption(self) -> str:

--- a/followthemoney/rdf.py
+++ b/followthemoney/rdf.py
@@ -1,9 +1,0 @@
-# This module serves exclusively to mitigate the type checking clusterfuck
-# that is rdflib 6.0.
-from rdflib import Namespace
-from rdflib.term import Identifier, URIRef, Literal
-from rdflib import RDF, SKOS, XSD
-
-NS = Namespace("https://schema.followthemoney.tech/#")
-
-__all__ = ["NS", "XSD", "RDF", "SKOS", "Identifier", "URIRef", "Literal"]

--- a/followthemoney/schema.py
+++ b/followthemoney/schema.py
@@ -46,7 +46,6 @@ class SchemaSpec(TypedDict, total=False):
     edge: EdgeSpec
     temporalExtent: TemporalExtentSpec
     description: Optional[str]
-    rdf: Optional[str]
     abstract: bool
     hidden: bool
     generated: bool
@@ -89,7 +88,6 @@ class Schema:
         "_plural",
         "_description",
         "_hash",
-        "uri",
         "abstract",
         "hidden",
         "generated",

--- a/followthemoney/schema.py
+++ b/followthemoney/schema.py
@@ -15,7 +15,6 @@ from functools import lru_cache
 from followthemoney.property import Property, PropertySpec, PropertyToDict, ReverseSpec
 from followthemoney.types import registry
 from followthemoney.exc import InvalidData, InvalidModel
-from followthemoney.rdf import URIRef, NS
 from followthemoney.util import gettext
 
 if TYPE_CHECKING:
@@ -124,9 +123,6 @@ class Schema:
         self._plural = data.get("plural", self.label)
         self._description = data.get("description")
         self._hash = hash("<Schema(%r)>" % name)
-
-        #: RDF identifier for this schema when it is transformed to a triple term.
-        self.uri = URIRef(cast(str, data.get("rdf", NS[name])))
 
         #: Do not store or emit entities of this type, it is used only for
         #: inheritance.

--- a/followthemoney/schema/Contract.yaml
+++ b/followthemoney/schema/Contract.yaml
@@ -68,4 +68,3 @@ Contract:
     language:
       label: "Language"
       type: language
-      rdf: http://purl.org/dc/terms/language

--- a/followthemoney/schema/Document.yaml
+++ b/followthemoney/schema/Document.yaml
@@ -30,12 +30,10 @@ Document:
     title:
       label: "Title"
       type: string
-      rdf: http://purl.org/dc/elements/1.1/title
       caption: true
     author:
       label: "Author"
       description: "The original author, not the uploader"
-      rdf: http://purl.org/dc/elements/1.1/creator
     generator:
       label: "Generator"
       description: "The program used to generate this file"
@@ -61,11 +59,9 @@ Document:
     mimeType:
       label: "MIME type"
       type: mimetype
-      rdf: http://purl.org/dc/terms/format
     language:
       label: "Language"
       type: language
-      rdf: http://purl.org/dc/terms/language
     translatedLanguage:
       label: "The language of the translated text"
       hidden: true
@@ -78,7 +74,6 @@ Document:
       label: "Date"
       description: "If not otherwise specified"
       type: date
-      rdf: http://purl.org/dc/elements/1.1/date
     authoredAt:
       label: "Authored on"
       type: date
@@ -95,7 +90,6 @@ Document:
         name: children
         label: "Child documents"
         hidden: true
-      rdf: http://purl.org/dc/terms/isPartOf
     ancestors:
       label: "Ancestors"
       type: entity

--- a/followthemoney/schema/Page.yaml
+++ b/followthemoney/schema/Page.yaml
@@ -21,7 +21,6 @@ Page:
         name: pages
         label: "Pages"
         hidden: true
-      rdf: http://purl.org/dc/terms/isPartOf
     detectedLanguage:
       label: "Detected language"
       type: language

--- a/followthemoney/schema/Person.yaml
+++ b/followthemoney/schema/Person.yaml
@@ -6,7 +6,6 @@ Person:
   description: >
     A natural person, as opposed to a corporation of some type.
   matchable: true
-  rdf: http://xmlns.com/foaf/0.1/Person
   featured:
     - name
     - nationality
@@ -26,14 +25,12 @@ Person:
   properties:
     title:
       label: Title
-      rdf: http://xmlns.com/foaf/0.1/title
     # The `firstName`, `lastName`, `secondName` etc. properties intentionally do not use
     # the `name` property type. Many FtM tools (including Aleph) use name properties to
     # compare/match entities, but matching entites just on e.g. a first name would lead to
     # too many false positives.
     firstName:
       label: First name
-      rdf: http://xmlns.com/foaf/0.1/givenName
     secondName:
       label: Second name
     middleName:
@@ -44,13 +41,11 @@ Person:
       label: Matronymic
     lastName:
       label: Last name
-      rdf: http://xmlns.com/foaf/0.1/lastName
     nameSuffix:
       label: Name suffix
     birthDate:
       label: Birth date
       type: date
-      rdf: http://xmlns.com/foaf/0.1/birthday
     birthPlace:
       label: Place of birth
     birthCountry:

--- a/followthemoney/schema/Thing.yaml
+++ b/followthemoney/schema/Thing.yaml
@@ -14,7 +14,6 @@ Thing:
     name:
       label: Name
       type: name
-      rdf: http://www.w3.org/2004/02/skos/core#prefLabel
     summary: # a short one-liner kind of description
       label: Summary
       type: text
@@ -27,7 +26,6 @@ Thing:
     alias:
       label: Other name
       type: name
-      rdf: http://www.w3.org/2004/02/skos/core#altLabel
     previousName:
       label: Previous name
       type: name

--- a/followthemoney/types/checksum.py
+++ b/followthemoney/types/checksum.py
@@ -1,4 +1,3 @@
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.types.common import PropertyType
 from followthemoney.util import defer as _
 
@@ -20,6 +19,3 @@ class ChecksumType(PropertyType):
     matchable = True
     pivot = True
     max_length = 40
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(f"hash:{value}")

--- a/followthemoney/types/common.py
+++ b/followthemoney/types/common.py
@@ -5,7 +5,6 @@ from banal import ensure_list
 from normality import stringify
 from typing import Any, Dict, Optional, Sequence, Callable, TYPE_CHECKING, TypedDict
 
-from followthemoney.rdf import Literal, Identifier
 from followthemoney.util import get_locale
 from followthemoney.util import gettext, sanitize_text
 
@@ -164,11 +163,6 @@ class PropertyType(object):
         """Determine if the given value allows us to infer a country that it may
         be related to (e.g. using a country prefix on a phone number or IBAN)."""
         return None
-
-    def rdf(self, value: str) -> Identifier:
-        """Return an RDF term to represent the given value - either a string
-        literal, or a URI reference."""
-        return Literal(value)
 
     def pick(self, values: Sequence[str]) -> Optional[str]:
         """Pick the best value to show to the user."""

--- a/followthemoney/types/country.py
+++ b/followthemoney/types/country.py
@@ -3,7 +3,6 @@ from typing import Optional, TYPE_CHECKING
 from babel.core import Locale
 from rigour.territories import get_territory, get_ftm_countries
 
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.types.common import EnumType, EnumValues
 from followthemoney.util import defer as _
 
@@ -52,6 +51,3 @@ class CountryType(EnumType):
 
     def country_hint(self, value: str) -> str:
         return value
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(f"iso-3166:{value}")

--- a/followthemoney/types/date.py
+++ b/followthemoney/types/date.py
@@ -4,7 +4,6 @@ from typing import Optional, TYPE_CHECKING
 from prefixdate import parse, parse_format, Precision
 
 from followthemoney.types.common import PropertyType
-from followthemoney.rdf import XSD, Literal, Identifier
 from followthemoney.util import defer as _
 from followthemoney.util import dampen
 
@@ -56,11 +55,6 @@ class DateType(PropertyType):
     def compare(self, left: str, right: str) -> float:
         prefix = os.path.commonprefix([left, right])
         return dampen(4, 10, prefix)
-
-    def rdf(self, value: str) -> Identifier:
-        if len(value) < Precision.HOUR.value:
-            return Literal(value, datatype=XSD.date)
-        return Literal(value, datatype=XSD.dateTime)
 
     def node_id(self, value: str) -> str:
         return f"date:{value}"

--- a/followthemoney/types/email.py
+++ b/followthemoney/types/email.py
@@ -4,7 +4,6 @@ from typing import Optional, TYPE_CHECKING
 from urllib.parse import urlparse
 from normality.cleaning import strip_quotes
 
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.types.common import PropertyType
 from followthemoney.util import sanitize_text, defer as _
 
@@ -80,6 +79,3 @@ class EmailType(PropertyType):
 
     # def country_hint(self, value)
     # TODO: do we want to use TLDs as country evidence?
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef("mailto:%s" % value.lower())

--- a/followthemoney/types/entity.py
+++ b/followthemoney/types/entity.py
@@ -2,7 +2,6 @@ import re
 from typing import Any, Optional, TYPE_CHECKING
 
 from followthemoney.types.common import PropertyType
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.util import ENTITY_ID_LEN, get_entity_id, sanitize_text
 from followthemoney.util import gettext, defer as _
 from followthemoney.exc import InvalidData
@@ -66,9 +65,6 @@ class EntityType(PropertyType):
         if self.REGEX.match(text) is not None:
             return text
         return None
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(f"entity:{value}")
 
     def caption(self, value: str) -> None:
         return None

--- a/followthemoney/types/gender.py
+++ b/followthemoney/types/gender.py
@@ -2,7 +2,6 @@ from typing import Optional, TYPE_CHECKING
 from babel.core import Locale
 
 from followthemoney.types.common import EnumType, EnumValues
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.util import gettext, defer as _
 
 if TYPE_CHECKING:
@@ -61,6 +60,3 @@ class GenderType(EnumType):
         if code not in self.codes:
             return None
         return code
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(f"gender:{value}")

--- a/followthemoney/types/iban.py
+++ b/followthemoney/types/iban.py
@@ -2,7 +2,6 @@ from typing import Optional, TYPE_CHECKING
 from rigour.ids import IBAN
 
 from followthemoney.types.common import PropertyType
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.util import sanitize_text, defer as _
 
 if TYPE_CHECKING:
@@ -47,9 +46,6 @@ class IbanType(PropertyType):
 
     def country_hint(self, value: str) -> str:
         return value[:2].lower()
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(self.node_id(value))
 
     def node_id(self, value: str) -> str:
         return f"iban:{value.upper()}"

--- a/followthemoney/types/ip.py
+++ b/followthemoney/types/ip.py
@@ -2,7 +2,6 @@ from typing import Optional, TYPE_CHECKING
 from ipaddress import ip_address
 
 from followthemoney.types.common import PropertyType
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.util import defer as _
 
 if TYPE_CHECKING:
@@ -45,6 +44,3 @@ class IpType(PropertyType):
             return str(ip_address(text))
         except ValueError:
             return None
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(f"ip:{value}")

--- a/followthemoney/types/language.py
+++ b/followthemoney/types/language.py
@@ -3,7 +3,6 @@ from babel.core import Locale
 from rigour.langs import iso_639_alpha3
 
 from followthemoney.types.common import EnumType, EnumValues
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.util import defer as _, gettext
 from followthemoney.util import get_env_list
 
@@ -120,6 +119,3 @@ class LanguageType(EnumType):
         if code not in self.LANGUAGES:
             return None
         return code
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(f"iso-639:{value}")

--- a/followthemoney/types/mimetype.py
+++ b/followthemoney/types/mimetype.py
@@ -3,7 +3,6 @@ from rigour.mime import normalize_mimetype, parse_mimetype
 from rigour.mime import DEFAULT
 
 from followthemoney.types.common import PropertyType
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.util import defer as _
 
 if TYPE_CHECKING:
@@ -36,9 +35,6 @@ class MimeType(PropertyType):
         if text != DEFAULT:
             return text
         return None
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(f"urn:mimetype:{value}")
 
     def caption(self, value: str) -> str:
         return parse_mimetype(value).label or value

--- a/followthemoney/types/phone.py
+++ b/followthemoney/types/phone.py
@@ -5,7 +5,6 @@ from phonenumbers import PhoneNumber, PhoneNumberFormat
 from phonenumbers.phonenumberutil import region_code_for_number, NumberParseException
 
 from followthemoney.types.common import PropertyType
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.util import defer as _
 from followthemoney.util import dampen
 
@@ -96,12 +95,6 @@ class PhoneType(PropertyType):
     def _specificity(self, value: str) -> float:
         # TODO: insert artificial intelligence here.
         return dampen(7, 11, value)
-
-    def rdf(self, value: str) -> Identifier:
-        node_id = self.node_id(value)
-        if node_id is not None:
-            return URIRef(node_id)
-        raise ValueError("Invalid phone number for serialisation: %s" % value)
 
     def node_id(self, value: str) -> Optional[str]:
         return f"tel:{value}"

--- a/followthemoney/types/topic.py
+++ b/followthemoney/types/topic.py
@@ -1,7 +1,6 @@
 from babel.core import Locale
 
 from followthemoney.types.common import EnumType, EnumValues
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.util import gettext, defer as _
 
 
@@ -89,6 +88,3 @@ class TopicType(EnumType):
 
     def _locale_names(self, locale: Locale) -> EnumValues:
         return {k: gettext(v) for (k, v) in self._TOPICS.items()}
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(f"ftm:topic:{value}")

--- a/followthemoney/types/url.py
+++ b/followthemoney/types/url.py
@@ -2,7 +2,6 @@ from typing import Optional, TYPE_CHECKING
 from rigour.urls import clean_url, compare_urls
 
 from followthemoney.types.common import PropertyType
-from followthemoney.rdf import URIRef, Identifier
 from followthemoney.util import dampen, defer as _
 
 if TYPE_CHECKING:
@@ -41,9 +40,6 @@ class UrlType(PropertyType):
 
     def _specificity(self, value: str) -> float:
         return dampen(10, 120, value)
-
-    def rdf(self, value: str) -> Identifier:
-        return URIRef(value)
 
     def node_id(self, value: str) -> Optional[str]:
         return f"url:{value}"

--- a/tests/export/test_rdf.py
+++ b/tests/export/test_rdf.py
@@ -1,9 +1,10 @@
 import os
-from unittest import TestCase
 from tempfile import mkstemp
+from rdflib import Graph, URIRef
+from rdflib.namespace import RDF
 
 from followthemoney import model
-from followthemoney.export.rdf import RDFExporter
+from followthemoney.export.rdf import RDFExporter, NS
 
 
 ENTITY = {
@@ -12,6 +13,7 @@ ENTITY = {
     "properties": {
         "name": ["Ralph Tester"],
         "birthDate": ["1972-05-01"],
+        "nationality": ["us"],
         "idNumber": ["9177171", "8e839023"],
         "website": ["https://ralphtester.me"],
         "phone": ["+12025557612"],
@@ -20,19 +22,27 @@ ENTITY = {
 }
 
 
-class ExcelExportTestCase(TestCase):
-    def setUp(self):
-        _, self.temp = mkstemp(suffix=".rdf")
+def test_rdf_export():
+    _, temp_path = mkstemp(suffix=".rdf")
+    fh = open(temp_path, "w+")
+    entity = model.get_proxy(ENTITY)
+    exporter = RDFExporter(fh)
+    exporter.write(entity)
+    exporter.finalize()
+    fh.seek(0)
 
-    def tearDown(self):
-        os.unlink(self.temp)
+    graph = Graph()
+    graph.parse(fh, format="nt")
+    assert len(graph) == 10, len(graph)
 
-    def test_rdf_export(self):
-        fh = open(self.temp, "w+")
-        entity = model.get_proxy(ENTITY)
-        exporter = RDFExporter(fh)
-        exporter.write(entity)
-        exporter.finalize()
-        fh.seek(0)
-        data = fh.readlines()
-        assert len(data) == 8, len(data)
+    nodes = graph.all_nodes()
+    assert URIRef("e:person") in nodes
+    assert URIRef("mailto:info@ralphtester.me") in nodes
+    assert URIRef("https://ralphtester.me") in nodes
+    assert URIRef("http://id.loc.gov/vocabulary/countries/us") in nodes
+    for _, _, v in graph.triples((URIRef("e:person"), NS["name"], None)):
+        assert v == "Ralph Tester"
+    for _, _, v in graph.triples((URIRef("e:person"), RDF.type, None)):
+        assert v == NS[entity.schema.name]
+
+    os.unlink(temp_path)


### PR DESCRIPTION
This consolidates all RDF-export related code into one module. Until now the support for RDF was sprinkled all over the code base. Given that it's not actually used by anyone in the real world, having it in one place - and making the loading of `rdflib` optional at run-time - seems like a more clear approach. 