### PR TITLE
Numbers with units parsing

### DIFF
--- a/followthemoney/types/number.py
+++ b/followthemoney/types/number.py
@@ -13,7 +13,17 @@ class NumberType(PropertyType):
     In the future we might want to enable annotations for format, units, or
     even to introduce a separate property type for monetary values."""
 
-    CAST_RE = re.compile(r"[^0-9\-\.]")
+    DECIMAL = "."
+    SEPARATOR = ","
+    PRECISION = 2
+
+    _NUM_UNIT_RE = (
+        f"(\\s?\\-?\\s?\\d+(?:{re.escape(DECIMAL)}\\d+)?)\\s*([^\\s\\d][^\\s]*)?"
+    )
+    NUM_UNIT_RE = re.compile(_NUM_UNIT_RE, re.UNICODE)
+    _FLOAT_FMT = "{:" + SEPARATOR + "." + str(PRECISION) + "f}"
+    _INT_FMT = "{:" + SEPARATOR + "d}"
+
     name = "number"
     label = _("Number")
     plural = _("Numbers")
@@ -22,9 +32,53 @@ class NumberType(PropertyType):
     def node_id(self, value: str) -> None:
         return None
 
+    def parse(
+        self, value: str, decimal: str = DECIMAL, separator: str = SEPARATOR
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Parse a number into a numeric value and a unit. The numeric value is
+        aligned with the decimal and separator settings. The unit is stripped of
+        whitespace and returned as a string. If no unit is found, None is
+        returned. If no number is found, None is returned for both values."""
+        value = value.replace(separator, "")
+        if decimal != self.DECIMAL:
+            value = value.replace(decimal, self.DECIMAL)
+        match = self.NUM_UNIT_RE.match(value)
+        if not match:
+            return None, None
+        number, unit = match.groups()
+        if unit is not None:
+            unit = unit.strip()
+            if len(unit) == 0:
+                unit = None
+        # TODO: We could have a lookup table for common units, e.g. kg, m, etc. to
+        # convert them to a standard form.
+        number = number.replace(" ", "")
+        if number == "":
+            number = None
+        return number, unit
+
     def to_number(self, value: str) -> Optional[float]:
         try:
-            value = self.CAST_RE.sub("", value)
-            return float(value)
+            number, _ = self.parse(value)
+            if number is None:
+                return None
+            return float(number)
         except Exception:
             return None
+
+    def caption(self, value: str) -> str:
+        """Return a caption for the number. This is used for display purposes."""
+        number, unit = self.parse(value)
+        if number is None:
+            return value
+        try:
+            fnumber = float(number)
+        except ValueError:
+            return value
+        if fnumber.is_integer():
+            number = self._INT_FMT.format(int(fnumber))
+        else:
+            number = self._FLOAT_FMT.format(fnumber)
+        if unit is not None:
+            return f"{number} {unit}"
+        return number

--- a/tests/types/test_number.py
+++ b/tests/types/test_number.py
@@ -9,3 +9,23 @@ def test_cast_numbers():
     assert numbers.to_number("- 1,00,000.234") == -100000.234
     assert numbers.to_number("99") == 99.0
     assert numbers.to_number("banana") is None
+
+
+def test_parse_numbers():
+    assert numbers.parse("99") == ("99", None)
+    assert numbers.parse("1,00,000") == ("100000", None)
+    assert numbers.parse(" -999.0") == ("-999.0", None)
+    assert numbers.parse("- 1,00,000.234") == ("-100000.234", None)
+    assert numbers.parse("banana") == (None, None)
+    assert numbers.parse("5 kg") == ("5", "kg")
+    assert numbers.parse("5kg") == ("5", "kg")
+    assert numbers.parse("42 °C") == ("42", "°C")
+
+
+def test_format_numbers():
+    assert numbers.caption("100000") == "100,000"
+    assert numbers.caption("-999.0") == "-999"
+    assert numbers.caption("-100000.234") == "-100,000.23"
+    assert numbers.caption("-100000.234tonnes") == "-100,000.23 tonnes"
+    assert numbers.caption("banana") == "banana"
+    assert numbers.caption("1,00,000") == "100,000"


### PR DESCRIPTION
This is an attempt to implement what I understand to be @tillprochaska's current approach to number parsing in FtM. It's not being adopted in `clean_text` for the moment, to avoid the shock of suddenly making vast sections of mapped data invalid. Should we make it required? 