### PR TITLE
feat: ensure valid dataset names

### DIFF
--- a/followthemoney/dataset/dataset.py
+++ b/followthemoney/dataset/dataset.py
@@ -12,6 +12,7 @@ from followthemoney.dataset.resource import DataResource
 from followthemoney.dataset.util import (
     Named,
     cleanup,
+    dataset_name_check,
     string_list,
     type_check,
     type_require,
@@ -32,7 +33,7 @@ class Dataset(Named):
     A dataset is a set of data, sez W3C."""
 
     def __init__(self: Self, data: Dict[str, Any]) -> None:
-        name = type_require(registry.string, data.get("name"))
+        name = dataset_name_check(data.get("name"))
         super().__init__(name)
         self.title = type_require(registry.string, data.get("title", name))
         self.license = type_check(registry.url, data.get("license"))

--- a/followthemoney/dataset/util.py
+++ b/followthemoney/dataset/util.py
@@ -1,4 +1,4 @@
-from normality import stringify
+from normality import stringify, slugify
 from prefixdate import parse as prefix_parse
 from typing import Any, Dict, List, Optional
 
@@ -39,6 +39,16 @@ def int_check(value: Any) -> Optional[int]:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def dataset_name_check(value: Any) -> str:
+    """Check that the given value is a valid dataset name. This doesn't convert
+    or clean invalid names, but raises an error if they are not compliant to
+    force the user to fix an invalid name"""
+    cleaned = type_require(registry.string, value)
+    if slugify(cleaned, sep="_") != cleaned:
+        raise MetadataException("Invalid %s: %r" % ("dataset name", value))
+    return cleaned
 
 
 def string_list(value: Any) -> List[str]:

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,4 +1,5 @@
 import json
+from re import I
 import pytest
 from pathlib import Path
 from typing import Any, Dict
@@ -114,3 +115,16 @@ def test_dataset_aleph_metadata(catalog_data: Dict[str, Any]):
             "coverage": {"frequency": "foo"},
         }
         ds = Dataset(meta)
+
+
+def test_dataset_name_validation():
+    with pytest.raises(MetadataException):
+        Dataset({"name": "my dataset"})
+    with pytest.raises(MetadataException):
+        Dataset({"name": "My-dataset"})
+    with pytest.raises(MetadataException):
+        Dataset({"name": "_test"})
+    with pytest.raises(MetadataException):
+        Dataset({"name": "ä_dataset"})
+    with pytest.raises(MetadataException):
+        Dataset({"name": "another.invalid.name"})

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,5 +1,4 @@
 import json
-from re import I
 import pytest
 from pathlib import Path
 from typing import Any, Dict
@@ -121,7 +120,9 @@ def test_dataset_name_validation():
     with pytest.raises(MetadataException):
         Dataset({"name": "my dataset"})
     with pytest.raises(MetadataException):
-        Dataset({"name": "My-dataset"})
+        Dataset({"name": "my-dataset"})
+    with pytest.raises(MetadataException):
+        Dataset({"name": "My_dataset"})
     with pytest.raises(MetadataException):
         Dataset({"name": "_test"})
     with pytest.raises(MetadataException):


### PR DESCRIPTION
This ensures dataset names are valid. This means:
- only lowercase ascii characters
- no whitespace
- no other special chars than `_`
- no `_` at the beginning or end
- (see test)